### PR TITLE
Restrict get authorization event to a single blob or server

### DIFF
--- a/buds/01.md
+++ b/buds/01.md
@@ -46,7 +46,7 @@ Servers must perform the following checks in order to validate the event
 
 1. The `kind` must be `24242`
 2. `created_at` must be in the past
-3. The `expiration` tag must be set to a Unix timespamp in the future
+3. The `expiration` tag must be set to a Unix timestamp in the future
 4. The `t` tag must have a verb matching the intended action of the endpoint
 5. Additional checks for specific endpoints. `/upload`, `/delete`, etc
 
@@ -92,28 +92,48 @@ This ensures that if a user was to copy or reuse the redirect URL it would still
 
 ### Get Authorization (optional)
 
-The server may optionally require authorization when fetching blobs from the `GET /<sha256>` endpoint
+The server may optionally require authorization when reteriving blobs from the `GET /<sha256>` endpoint
 
 In this case the server MUST perform additional checks on the authorization event
 
-1. The `t` tag must be set to `get`
+1. A `t` tag MUST be present and set to `get`
+2. The event MUST contain either a `server` tag containing the full URL to the server or MUST contain an `x` tag with the sha256 of the blob being retrieved
 
 If the client did not send an `Authorization` header the server must respond with the appropriate HTTP status code `401` (Unauthorized)
 
-Example Authorization event:
+Example event for retreiving a single blob:
 
 ```json
 {
-  "id": "3a2c0a58f88f86ab81ce7d111df57096e8cd9f41a75731a021e06e07c6df9d0e",
-  "pubkey": "96ddb0e7c4a5786a842094fee014d4c6cbb1f1627a8d75ef6fb601baeb6c5054",
+  "id": "06d4842b9d7f8bf72440471704de4efa9ef8f0348e366d097405573994f66294",
+  "pubkey": "ec0d11351457798907a3900fe465bfdc3b081be6efeb3d68c4d67774c0bc1f9a",
   "kind": 24242,
-  "content": "Get Blobs",
+  "content": "Get bitcoin.pdf",
   "created_at": 1708771927,
   "tags": [
     ["t", "get"],
-    ["expiration", "1708857340"]
+    ["expiration", "1708857340"],
+    ["x", "b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553"]
   ],
-  "sig": "2f279b2ac0a5d5f7551f5612b69a111e038ab6b31233a78bfc98f63bd5e38ae8cb5929cf7427f0b7b2dd5eff29e769df23d93926326b0d059dc475701a41d6d3"
+  "sig": "22ecb5116ba143e4c3d6dc4b53d549aed6970ec455f6d25d145e0ad1fd7c0e26c465b2e92d5fdf699c7050fa43e6a41f087ef167208d4f06425f61548168fd7f"
+}
+```
+
+Example event for retreiving multiple blobs from single server:
+
+```json
+{
+  "id": "d9484f18533d5e36f000f902a45b15a7eecf5fbfcb046789756d57ea87115dc5",
+  "pubkey": "b5f07faa8d3529f03bd898a23dfb3257bab8d8f5490777c46076ff9647e205dc",
+  "kind": 24242,
+  "content": "Get blobs from example.com",
+  "created_at": 1708771927,
+  "tags": [
+    ["t", "get"],
+    ["expiration", "1708857340"],
+    ["server", "https://cdn.example.com/"]
+  ],
+  "sig": "e402ade78e1714d40cd6bd3091bc5f4ada8e904e90301b5a2b9b5f0b6e95ce908d4f22b15e9fb86f8268a2131f8adbb3d1f0e7e7afd1ab0f4f08acb15822a999"
 }
 ```
 


### PR DESCRIPTION
This PR restricts the `GET /<sha256>` authorization to either a single blob sha256 or a single server.

It does this by requiring the get authorization event to either have a `x` tag with the sha256 ( `["x","b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553"]` ) or a `server` tag with the servers URL ( `["server", "https://cdn.example.com/"]` )

This prevents malicious servers from reusing get auth events to impersonate the user with other servers

Example:
Server `A` and `B` both require authorization to read blobs
User creates an authorization event to read blobs and sends it to `B` to retrieve a single blob
Server `B` returns the blob but is malicious and reuses the users authorization event to talk to server `A` as the user to retrieve other blobs