### PR TITLE
Mirroring blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Blossom Servers expose four endpoints for managing blobs
   - `Authentication` _(optional)_: Signed [nostr event](./buds/01.md#list-authorization-optional)
 - `DELETE /<sha256>` [BUD-2](./buds/02.md#delete-sha256---delete-blob)
   - `Authentication`: Signed [nostr event](./buds/01.md#delete-authorization-required)
+- `PUT /mirror` [BUD-04](./buds/04.md#put-mirror---mirror-blob)
+  - `Authentication`: Signed [nostr event](./buds/01.md#upload-authorization-required)
 
 ## Protocol specification (BUDs)
 

--- a/buds/01.md
+++ b/buds/01.md
@@ -2,7 +2,7 @@ BUD-01
 ======
 
 Server requirements and blob reterival
----------------------
+--------------------------------------
 
 `draft` `mandatory`
 

--- a/buds/02.md
+++ b/buds/02.md
@@ -2,7 +2,7 @@ BUD-02
 ======
 
 Blob upload and management
----------------------
+--------------------------
 
 `draft` `optional`
 

--- a/buds/04.md
+++ b/buds/04.md
@@ -2,7 +2,7 @@ BUD-04
 ======
 
 Mirroring blobs
----------------------
+---------------
 
 `draft` `optional`
 


### PR DESCRIPTION
This PR defines an optional `/mirror` endpoint that can be used to tell a server where to download the blob instead of the client uploading it