### PR TITLE
BUD-09 Attribution

### DIFF
--- a/buds/09.md
+++ b/buds/09.md
@@ -1,0 +1,19 @@
+# BUD-09
+
+## Attribution
+
+`draft` `optional`
+
+In order to provide a better experience to creators, servers can include additional signing requirements to make it possible to link back to the original owners of blobs.
+
+### Response Headers
+
+An addional header will be returned along with the blob:
+
+Option 1:
+- `X-Signature`: A NIP-19 encoded `nsig` by the creator, 
+  - `special`: The bare signature of the file hash
+  - `author`: The public key of the author 
+
+Option 2:
+- `X-Auth-By`: Returns the base64 encoded `authorization` event used to upload the file.


### PR DESCRIPTION
Idea: Content creators want to allow people to share their media but also make it possible for the viewers of the media to be able to trace back to the original creator of the content.

This DOES NOT SOLVE any copy/pasta problems.

There are 2 options because NIP-07 signers dont expose a simple `signHash` method but also the hash was signed in the authorisation event, ideally we could use `Option 1` since its the most direct solution.

Let me know what you think