### PR TITLE
Change auth  for upload as optional

### DIFF
--- a/buds/02.md
+++ b/buds/02.md
@@ -42,9 +42,9 @@ The endpoint MUST return a [Blob Descriptor](#blob-descriptor) if the upload was
 
 Servers MAY reject an upload for any reason and should respond with the appropriate HTTP `4xx` status code and an error message explaining the reason for the rejection
 
-### Upload Authorization (required)
+### Upload Authorization (Optional)
 
-Servers MUST accept an authorization event when uploading blobs and should perform additional checks
+Servers MAY accept an authorization event when uploading blobs and should perform additional checks
 
 1. The `t` tag MUST be set to `upload`
 2. MUST contain at least one `x` tag matching the sha256 hash of the blob being uploaded
@@ -67,7 +67,7 @@ Example Authorization event:
 }
 ```
 
-## GET /list/pubkey - List Blobs
+## GET /list/pubkey - List Blobs (Optional)
 
 The `/list/<pubkey>` endpoint MUST return a JSON array of [Blob Descriptor](#blob-descriptor) that where uploaded by the specified pubkey
 


### PR DESCRIPTION
Because of the paid blossom spec. Nostr auth for the the upload endpoint should change as optional. 

Because of this change "list/pubkey" should be also changed to optional. 