### PR TITLE
BUD-10: API Keys

### DIFF
--- a/buds/10.md
+++ b/buds/10.md
@@ -1,0 +1,44 @@
+# API Keys
+
+`draft` `optional`
+
+Grant access to external services to perform actions on your behlaf.
+
+## POST /auth - Authorize a new key
+
+**Authorization required**
+
+Create or Update an authorization to allow another pubkey to perform actions on your behalf.
+
+Because every request is signed, this key SHOULD be a generated for the sole purpose of uploading on behalf of another user, 
+if the requested key already exists the server MUST reject the request.
+
+```json
+// request body
+{
+  "pubkey": "<hex-pubkey>",
+  "permissions": [
+    "upload_blob", "delete_blob"
+  ],
+  "expiration": 1731256197 // optional
+}
+```
+
+`permissions` contains a list of grants, below is a list of grants and URL endpoints from other BUDS.
+
+| name | endpoint | bud |
+| - | - | - |
+| `upload_blob` | `PUT /upload` | BUD-02 |
+| `delete_blob` | `DELETE /<sha256>` | BUD-02 |
+| `mirror_blob` | `PUT /mirror` | BUD-04 |
+
+`expiration` defines when access for this key should no longer be allowed. This is optional.
+
+## DELETE /auth/&lt;pubkey&gt; - Remove an authorized key
+
+**Authorization required**
+
+Delete an authorized key entry, resposne codes:
+
+- `200`: Key was deleted
+- `404`: Key was not found


### PR DESCRIPTION
Allow access for 3rd parties to upload/delete blobs.

[Read](https://github.com/v0l/blossom/blob/auth-key/buds/10.md)

In some cases it would useful to allow temporary access for external services to upload data to your account.

In this BUD "API Keys" refers to "Nostr private keys", keys generated only for the purposes of accessing another users blossom server.