### PR TITLE
modify BUD-02: require the file extension in the url field

### DIFF
--- a/buds/02.md
+++ b/buds/02.md
@@ -12,11 +12,13 @@ Defines the `/upload`, `/list` and `DELETE /<sha256>` endpoints
 
 A blob descriptor is a JSON object containing `url`, `sha256`, `size`, `type`, and `uploaded` fields
 
-- `url` A publicly accessible URL to the [BUD-01](./01.md#get-sha256---get-blob) `GET /<sha256>` endpoint (optionally with a file extension)
+- `url` A publicly accessible URL to the [BUD-01](./01.md#get-sha256---get-blob) `GET /<sha256>` endpoint with a file extension
 - `sha256` The sha256 hash of the blob
 - `size` The size of the blob in bytes
 - `type` (optional) The MIME type of the blob
 - `uploaded` The unix timestamp of when the blob was uploaded to the server
+
+Servers MUST include a file extension in the URL in the `url` field to allow clients to easily embed the URL in social posts or other content
 
 Servers MAY include additional fields in the descriptor like `magnet`, `infohash`, or `ipfs` depending on other protocols they support
 


### PR DESCRIPTION
This PR makes the file extension required in the `url` field in the blob descriptor

The `url` field is intended to be a helper for clients to easily embed the blob in nostr posts or anywhere else so the file extension is useful

NOTE: The file extension in BUD-01 `GET /<sha256>` endpoint is still **optional**