### PR TITLE
Update BUD-05: Add HEAD /media endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Blobs are packs of binary data addressed by their sha256 hash
 
 ## How does it work?
 
-Blossom Servers expose four endpoints for managing blobs
+Blossom Servers expose a few endpoints for managing blobs
 
 - `GET /<sha256>` (optional file `.ext`) [BUD-01](./buds/01.md#get-sha256---get-blob)
 - `HEAD /<sha256>` (optional file `.ext`) [BUD-01](./buds/01.md#head-sha256---has-blob)
@@ -27,7 +27,8 @@ Blossom Servers expose four endpoints for managing blobs
   - `Authentication`: Signed [nostr event](./buds/02.md#delete-authorization-required)
 - `PUT /mirror` [BUD-04](./buds/04.md#put-mirror---mirror-blob)
   - `Authentication`: Signed [nostr event](./buds/02.md#upload-authorization-required)
-- `PUT /media` [BUD-05](./buds/05.md)
+- `HEAD /media` [BUD-05](./buds/05.md#head-media)
+- `PUT /media` [BUD-05](./buds/05.md#put-media)
   - `Authentication`: Signed [nostr event](./buds/05.md#upload-authorization)
 
 ## Protocol specification (BUDs)

--- a/buds/05.md
+++ b/buds/05.md
@@ -22,6 +22,10 @@ Servers MAY require an `upload` [authorization event](./02.md#upload-authorizati
 
 If a server requires an `upload` authorization event it MUST preform all the checks outlined in the [`/upload`](./02.md#upload-authorization-required) endpoint
 
+## HEAD /media
+
+Servers MUST respond to `HEAD` requests on the `/media` endpoint in a similar way to the `HEAD /upload` endpoint defined in [BUD-06](./06.md)
+
 ## Limitations
 
 This endpoint is intentionally limited to optimizing a single blob with the goal of making it easier to distribute


### PR DESCRIPTION
This PR adds a `HEAD /media` endpoint similar to `HEAD /upload` in BUD-06 but for the `PUT /media` endpoint defined in BUD-05 