### PR TITLE
Recomend range requests to BUD-01

### DIFF
--- a/buds/01.md
+++ b/buds/01.md
@@ -137,6 +137,6 @@ The endpoint MUST accept an optional file extension in the URL similar to the `G
 
 ## Range requests
 
-To better support mobile devices or low bandwidth connections. server should support range requests ([RFC 7233 section 3](https://www.rfc-editor.org/rfc/rfc7233#section-3)) on the `GET /<sha256>` endpoint and signal support using the `accept-ranges: bytes` and `content-length` headers on the `HEAD /<sha256>` endpoint
+To better support mobile devices, video files, or low bandwidth connections. servers should support range requests ([RFC 7233 section 3](https://www.rfc-editor.org/rfc/rfc7233#section-3)) on the `GET /<sha256>` endpoint and signal support using the `accept-ranges: bytes` and `content-length` headers on the `HEAD /<sha256>` endpoint
 
 See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) for more details


### PR DESCRIPTION
This PR adds a section to BUD-01 suggesting that servers support range requests on the main `GET /<sha256>` endpoint

fixes https://github.com/hzrd149/blossom/issues/37