### PR TITLE
Require NIP-94 values to be strings

### DIFF
--- a/buds/08.md
+++ b/buds/08.md
@@ -12,7 +12,7 @@ As described in [BUD-02](./02.md#blob-descriptor) servers MAY add any additional
 
 Servers MAY return an additional `nip94` field in the [blob descriptor](./02.md#blob-descriptor) from the `/upload` or `/mirror` endpoints
 
-The `nip94` field should contain a JSON object with the keys being the tag names defined in [NIP-94](https://github.com/nostr-protocol/nips/blob/master/94.md)
+The `nip94` field should contain a JSON object with the keys being the tag names defined in [NIP-94](https://github.com/nostr-protocol/nips/blob/master/94.md) and the values being strings
 
 An example response would look like:
 
@@ -27,7 +27,7 @@ An example response would look like:
 		"url": "https://cdn.example.com/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf",
 		"m": "application/pdf",
 		"x": "b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553",
-		"size": 184292,
+		"size": "184292",
 		"magnet": "magnet:?xt=urn:btih:9804c5286a3fb07b2244c968b39bc3cc814313bc&dn=bitcoin.pdf",
 		"i": "9804c5286a3fb07b2244c968b39bc3cc814313bc"
 	}


### PR DESCRIPTION
This PR fixes the example and requires the values in the `nip94` object to be strings to match NIP-01 tags

Fixes https://github.com/hzrd149/blossom/issues/48