### PR TITLE
Change /media endpoint to require "media" auth

### DIFF
--- a/buds/05.md
+++ b/buds/05.md
@@ -18,9 +18,12 @@ Servers MAY reject media uploads for any reason and should respond with the appr
 
 ### Upload Authorization
 
-Servers MAY require an `upload` [authorization event](./02.md#upload-authorization-required) to identify the uploader
+Servers MAY require a `media` [authorization event](./02.md#upload-authorization-required) to identify the uploader
 
-If a server requires an `upload` authorization event it MUST preform all the checks outlined in the [`/upload`](./02.md#upload-authorization-required) endpoint
+If a server requires a `media` authorization event it MUST preform the following checks
+
+1. The `t` tag MUST be set to `media`
+2. MUST contain at least one `x` tag matching the sha256 hash of the body of the request
 
 ## HEAD /media
 
@@ -40,6 +43,6 @@ If a longer optimization or transformation process is needed, or if the client n
 
 Clients MAY let a user selected a "trusted processing" server for uploading images or short videos
 
-Once a server has been selected, the client can upload the original media to the `/media` endpoint of the trusted server and get the optimized blob back
+Once a server has been selected, the client uploads the original media to the `/media` endpoint of the trusted server and get the optimized blob back
 
-Then optionally the client can ask the user to sign another `upload` authorization event for the new optimized blob and call the `/mirror` endpoint on other servers to distribute the blob
+Then the client can ask the user to sign another `upload` authorization event for the new optimized blob and call the `/mirror` endpoint on other servers to distribute the blob


### PR DESCRIPTION
This PR is technically a breaking change and would effect any client or server that has implemented BUD-05 to date

This changes the authorization type on `/media` endpoints to be `media` instead of `upload`. The reason for the change is to reduce the chance of a server re-publishing the original media blob to other servers using the `upload` auth event