### PR TITLE
Clarify authorization requirements in BUD-04

### DIFF
--- a/buds/04.md
+++ b/buds/04.md
@@ -19,11 +19,11 @@ Clients MUST pass the URL of the remote blob as a stringified JSON object in the
 }
 ```
 
-Clients MUST set the `Authorization` header to an upload authorization event defined in [BUD-02](./02.md#upload-authorization-required)
+Clients MAY set the `Authorization` header to an upload authorization event defined in [BUD-02](./02.md#upload-authorization-required). When using authorization, the event MUST be of type "upload".
 
 The `/mirror` endpoint MUST download the blob from the specified URL and verify that there is at least one `x` tag in the authorization event matching the sha256 hash of the download blob
 
-**Multiple `x` tags MUST NOT be interpreted as the user requesting a bulk mirror.**
+**Multiple `x` tags in the authorization event MUST NOT be interpreted as the user requesting a bulk mirror.**
 
 The endpoint MUST return a [Blob Descriptor](#blob-descriptor) if the mirroring was successful or an error object if it was not
 


### PR DESCRIPTION
This PR modifies the auth requirements in BUD-04 from "MUST" to "MAY"

It also clarifies that the authorization type that should be used on the `/mirror` endpoint should be an `"upload"` type. this was hinted at and was my original intention in the "Example Flow" but I neglected to explicitly mention it in the BUD