### PR TITLE
Use offset limit pagination instead of date based pagination

### DIFF
--- a/buds/02.md
+++ b/buds/02.md
@@ -73,7 +73,7 @@ Example Authorization event:
 
 The `/list/<pubkey>` endpoint MUST return a JSON array of [Blob Descriptor](#blob-descriptor) that where uploaded by the specified pubkey
 
-The endpoint MUST support a `since` and `until` query parameter to limit the returned blobs by their `uploaded` date
+The endpoint MUST support `limit`, `offset` query parameters for pagination. The returned array of blob descriptors MUST be sorted by the `uploaded` date in descending order
 
 Servers may reject a list for any reason and MUST respond with the appropriate HTTP `4xx` status code and an error message explaining the reason for the rejection
 

--- a/buds/02.md
+++ b/buds/02.md
@@ -73,7 +73,9 @@ Example Authorization event:
 
 The `/list/<pubkey>` endpoint MUST return a JSON array of [Blob Descriptor](#blob-descriptor) that where uploaded by the specified pubkey
 
-The endpoint MUST support `limit`, `offset` query parameters for pagination. The returned array of blob descriptors MUST be sorted by the `uploaded` date in descending order
+The endpoint MUST support `limit`, `offset` query parameters for offset limit based pagination. The returned array of blob descriptors MUST be sorted by the `uploaded` date in descending order
+
+The endpoint MUST support `cursor` and`limit` query parameters for cursor based pagination. The `cursor` parameter MUST be the `sha256` hash of the last blob in the previous page. The returned array of blob descriptors MUST be sorted by the `uploaded` date in descending order and should not include the blob at the cursor
 
 Servers may reject a list for any reason and MUST respond with the appropriate HTTP `4xx` status code and an error message explaining the reason for the rejection
 


### PR DESCRIPTION
The date based pagination on the `/list` endpoint was a mistake and is barely useful. this PR replaces it with something more useful