### PR TITLE
Add missing HEAD for CORS headers

### DIFF
--- a/buds/01.md
+++ b/buds/01.md
@@ -11,7 +11,7 @@ _All pubkeys MUST be in hex format_
 Servers MUST set the `Access-Control-Allow-Origin: *` header on all responses to ensure compatibility with applications hosted on other domains.
 
 For [preflight](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) (`OPTIONS`) requests,
-servers MUST also set, at minimum, the `Access-Control-Allow-Headers: Authorization, *` and `Access-Control-Allow-Methods: GET, PUT,
+servers MUST also set, at minimum, the `Access-Control-Allow-Headers: Authorization, *` and `Access-Control-Allow-Methods: GET, HEAD, PUT,
 DELETE` headers.
 
 The header `Access-Control-Max-Age: 86400` MAY be set to cache the results of a preflight request for 24 hours.

--- a/buds/09.md
+++ b/buds/09.md
@@ -6,7 +6,6 @@
 
 This bud defines a new endpoint for clients and users to report blobs to servers.
 
-
 ### PUT /report - reporting a blob
 
 The request body MUST be a signed [NIP-56](https://github.com/nostr-protocol/nips/blob/master/56.md) report event with one or more `x` tags containing the hashes of the blobs being reported.


### PR DESCRIPTION
This PR adds the missing `HEAD` method to the allowed methods header for CORS since BUD-01, and BUD-06 define `HEAD` endpoints