### PR TITLE
Clarify has blob endpoint in BUD-01

### DIFF
--- a/buds/01.md
+++ b/buds/01.md
@@ -75,11 +75,11 @@ All endpoints MUST be served from the root of the domain (eg. the `/upload` endp
 
 ## GET /sha256 - Get Blob
 
-The `GET /<sha256>` endpoint MUST return the contents of the blob with the `Content-Type` header set to the appropriate MIME-type
+The `GET /<sha256>` endpoint MUST return the contents of the blob in the response body. the `Content-Type` header SHOULD beset to the appropriate MIME-type
 
 The endpoint MUST accept an optional file extension in the URL. ie. `.pdf`, `.png`, etc
 
-If the endpoints returns a 301 or 302 redirect it MUST redirect to a URL containing the same sha256 hash as the requested blob.
+If the endpoint returns a `301` or `302` redirect it MUST redirect to a URL containing the same sha256 hash as the requested blob.
 This ensures that if a user was to copy or reuse the redirect URL it would still contain the original sha256 hash
 
 ### Get Authorization (optional)
@@ -131,7 +131,9 @@ Example event for retrieving multiple blobs from single server:
 
 ## HEAD /sha256 - Has Blob
 
-The `HEAD /<sha256>` endpoint MUST respond with either a `200` or `404` status code
+The `HEAD /<sha256>` endpoint MUST be identical to the `GET /<sha256>` endpoint except that it MUST NOT return the blob in the reponse body per [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.2)
+
+The endpoint MUST respond with the same headers that the `GET /<sha256>` endpoint would respond with including the `Content-Type` header and other content headers.
 
 The endpoint MUST accept an optional file extension in the URL similar to the `GET /<sha256>` endpoint. ie. `.pdf`, `.png`, etc
 

--- a/buds/01.md
+++ b/buds/01.md
@@ -131,9 +131,9 @@ Example event for retrieving multiple blobs from single server:
 
 ## HEAD /sha256 - Has Blob
 
-The `HEAD /<sha256>` endpoint MUST be identical to the `GET /<sha256>` endpoint except that it MUST NOT return the blob in the reponse body per [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.2)
+The `HEAD /<sha256>` endpoint SHOULD be identical to the `GET /<sha256>` endpoint except that it MUST NOT return the blob in the reponse body per [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.2)
 
-The endpoint MUST respond with the same headers that the `GET /<sha256>` endpoint would respond with including the `Content-Type` header and other content headers.
+The endpoint MUST respond with the same `Content-Type` and `Content-Length` headers as the `GET /<sha256>` endpoint.
 
 The endpoint MUST accept an optional file extension in the URL similar to the `GET /<sha256>` endpoint. ie. `.pdf`, `.png`, etc
 


### PR DESCRIPTION
This PR adds more clarification about how the `HEAD /<sha256>` endpoint should behave along with requiring it to return the same headers that the `GET /<sha256>` endpoint returns.

[RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.2) only states that:

> The server SHOULD send the same
> header fields in response to a HEAD request as it would have sent if
> the request had been a GET, except that the payload header fields
> ([Section 3.3](https://www.rfc-editor.org/rfc/rfc7231#section-3.3)) MAY be omitted.

I'm undecided if changing this from a SHOULD / MAY to a MUST is a good since it rules out simple servers that just want to respond with a `200` or `404` for checking if a blob exists. on the other hand it will make getting the blobs metadata ( `Content-Length` and `Content-Type` ) from the server easier for servers that do implement it


Fixes #45