### PR TITLE
BUD-10: Implement 'user backup lists' tag

### DIFF
--- a/buds/10.md
+++ b/buds/10.md
@@ -1,0 +1,134 @@
+# BUD-10
+
+## User backup lists
+
+`draft` `optional`
+
+This BUD defines a event using `kind:11063` to advertise the blossom servers a user uses to backup blobs of other authors.
+
+The event MUST include one or more `server` tags, containing the full server URL of the default Blossom server, including the `http://` or `https://`.
+
+The order of these tags is important and should be arranged with the users most "reliable" or "trusted" servers being first.
+
+The `.content` field is not used.
+
+```json
+{
+  "content": "",
+  "created_at": 1708774162,
+  "id": "237983c775aa8ce2f7fe1bdb604512d82e91215c5ef4b06dcca69d699dc7d850",
+  "kind": 11063,
+  "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  "sig": "341e8baa4f28035b8aa40d342932158f600b1c8ca82d3d1bb3928b590a46cb18ecd0888b558783c73fa282b0591e7c6b9ebef57499ce49122672065f0354f3b0",
+  "tags": [
+    [
+      "server",
+      "https://self.hosted"
+    ],
+    [
+      "server",
+      "https://another-self.hosted"
+    ]
+  ]
+}
+```
+
+---
+
+This BUD also defines an event using `kind:63` to advertise the blossom servers a user used to host blobs for specific authors or events.
+
+The event MAY include a list of `p` tags; each tag entry should contain the key for a author and optionally from the fourth position the full Blossom server URLs (including the `http://` or `https://`); if no URLs are specified it's assumed that the default `server` URLs are applied to the author (see below).
+
+The event MAY include a list of `e` tags; each tag entry should contain the key for an event and optionally from the fifth position the full Blossom server URL (including the `http://` or `https://`); if no URLs are specified it's assumed that the default `server` URLs are applied to the author (see below).
+
+The event MAY include one or more `server` tags, containing the full server URLs of some Blossom servers, (including the `http://` or `https://`), that are used if/where the `p` or `e` tags don't have a specific URL.
+This is useful to compact the event size when the user uses a single server for all the blobs.
+
+```
+{
+  "content": "",
+  "created_at": 1708774162,
+  "id": "054f1faf88a17269b17aa687da17d696965c7231186df063666361c84f77da14",
+  "kind": 63,
+  "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  "sig": "348995a0f5c7c06b0e35de7372f26ac34effdd4043f06025710894c0107ebde5c64c37fb7ea56a36be805a448719685195f7b275280554b79cf74685b65809b6",
+  "tags": [
+    [
+      "server",
+      "https://self.hosted"
+    ],
+    [
+      "server",
+      "https://another-self.hosted"
+    ],
+    [
+      "p",
+      "7bdef7be22dd8e59f4600e044aa53a1cf975a9dc7d27df5833bc77db784a5805"
+    ],
+    [
+      "p",
+      "fa5f9c95a7a198d827ed83b07b330c2e797a291e9a8379427ebcfd33e0e8167b"
+    ],
+    [
+      "p",
+      "75722154de90582cd1642a759edd3edb28dbc5bebca78ea66a004bd6e715c677",
+      "https://premium-self.hosted"
+    ],
+    [
+      "p",
+      "704f84535897954120518625e9f5de793148264adc21aef97cadbbe30dfbcdb5",
+      "https://premium-self.hosted",
+      "https://alt-self.hosted"
+    ],
+    [
+      "e",
+      "0fe6162076acef5fadd361e388d2a4752cd8ec837f4fe7df175e18f0014c8d9b",
+      "https://alt-self.hosted"
+    ]
+  ]
+}
+```
+
+## Client backup implementation
+
+When backing up blobs clients MUST attempt to upload the blob to at least the first `server` listed in the user kind:11063 backup server list.
+
+Optionally clients MAY upload the blob to all the servers or mirror the blob to the other servers.
+
+Optionally clients MAY generate a kind:63 with the information about the blobs backup, related to specific authors or events.  
+It is left up to the client to decide how to organize these events, such as grouping multiple authors into a single event, or multiple events by the same author in different events.
+
+## Client retrieval implementation
+
+Basic event parsing and retrieval MUST follow [BUD-03](./03.md) specs.
+
+If the author's list is not available or the blobs are not retrievable, the client SHOULD fallback first on the user's `kind:63` events and then on the `kind:11063` event to find out a server from whic successfully retrieve the blob.
+
+Take the following event as an example
+
+```json
+{
+  "id": "834185269f4ab72539193105060dbb1c8b2efd702d14481cea345c47beefe6eb",
+  "pubkey": "ec4425ff5e9446080d2f70440188e3ca5d6da8713db7bdeef73d0ed54d9093f0",
+  "content": "I've developed a new open source P2P e-cash system called Bitcoin. check it out\nhttps://cdn.broken-domain.com/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf",
+  "kind": 1,
+  "created_at": 1297484820,
+  "tags": [],
+  "sig": "bd4bb200bdd5f7ffe5dbc3e539052e27b05d6f9f528e255b1bc4261cc16b8f2ad85c89eef990c5f2eee756ef71b4c571ecf6a88ad12f7338e321dd60c6a903b5"
+}
+```
+
+Once the client discovers that the URL `https://cdn.broken-domain.com/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf` is no longer available. It can perform the following steps to find the blob:
+
+1. Get the SHA256 hash from the URL
+2. Look for the author server list `kind:10063` (see [BUD-03](./03.md))
+3. If found, attempt to retrieve the blob from each `server` listed starting with the first
+4. If not found, the client SHOULD look for the user backup `kind:63` event matching the event ID or the author's pubkey
+5. If found, attempt to retrieve the blob from the suggested servers
+6. If not found, the client SHOULD look for the user backup list`kind:11063`
+7. If found, attempt to retrieve the blob from each `server` listed starting with the first
+6. If not found, the client SHOULD look for `kind:63` events from other users, matching the wanted author or event
+7. If found, attempt to retrieve the blob from the suggested servers, cycling the found events
+8. If not found, the client MAY fallback to using a well-known popular Blossom server to retrieve the blob
+
+This ensures clients can quickly find missing blobs using the users list of trusted servers.


### PR DESCRIPTION
I'm going to release an update for [Chronicle](https://github.com/dtonon/chronicle) that supports backup of others' blobs, to have a really full copy of the conversation where the owner participated, media included.
If the original author of a note doesn't offer working backup locations, we risk being unable to retrieve their media. With the `fallback` tag the user can instruct the client to use some preferred additional servers, before falling back to the "well-known popular Blossom server" as a last resort.