### PR TITLE
Clarifying Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌸 Blossom - Blobs stored simply on mediaservers
 
-Blossom uses [nostr](https://github.com/nostr-protocol/nostr) public / private keys for identities. Users are expected to sign authorization events to prove their identity when interacting with servers
+Blossom uses [nostr](https://github.com/nostr-protocol/nostr) public / private keys for identities. Users are expected to sign authentication events to prove their identity when interacting with servers
 
 ## What is it?
 
@@ -54,7 +54,7 @@ Blossom Servers expose a few endpoints for managing blobs
 
 | kind    | description         | BUD                |
 | ------- | ------------------- | ------------------ |
-| `24242` | Authorization event | [01](./buds/01.md) |
+| `24242` | Authentication event | [01](./buds/01.md) |
 | `10063` | User Server List    | [03](./buds/03.md) |
 
 ## License

--- a/buds/01.md
+++ b/buds/01.md
@@ -20,11 +20,11 @@ The header `Access-Control-Max-Age: 86400` MAY be set to cache the results of a 
 
 Every time a server sends an error response (HTTP status codes >=400), it may include a human-readable header `X-Reason` that can be displayed to the user.
 
-## Authorization events
+## Authentication events
 
-Authorization events are used to identify the users to the server
+Authentication events are used to identify the users to the server
 
-Authorization events must be generic and must NOT be scoped to specific servers. This allows pubkeys to sign a single event and interact the same way with multiple servers.
+Authentication events must be generic and must NOT be scoped to specific servers. This allows pubkeys to sign a single event and interact the same way with multiple servers.
 
 Events MUST be kind `24242` and have a `t` tag with a verb of `get`, `upload`, `list`, or `delete`
 
@@ -32,7 +32,7 @@ Events MUST have the `content` set to a human readable string explaining to the 
 
 All events MUST have a [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) `expiration` tag set to a unix timestamp at which the event should be considered expired.
 
-Authorization events MAY have multiple `x` tags for endpoints that require a sha256 hash.
+Authentication events MAY have multiple `x` tags for endpoints that require a sha256 hash.
 
 Example event:
 
@@ -45,7 +45,7 @@ Example event:
   "created_at": 1708773959,
   "tags": [
     ["t", "upload"],
-    // Authorization events MAY have multiple "x" tags.
+    // Authentication events MAY have multiple "x" tags.
     ["x", "b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553"],
     ["expiration", "1708858680"]
   ],
@@ -103,7 +103,7 @@ include a file extension in the URL that reflects the blob type (e.g. `.bin`, `.
 
 The server may optionally require authorization when retrieving blobs from the `GET /<sha256>` endpoint
 
-In this case, the server MUST perform additional checks on the authorization event
+In this case, the server MUST perform additional checks on the authentication event
 
 1. A `t` tag MUST be present and set to `get`
 2. The event MUST contain either a `server` tag containing the full URL to the server or MUST contain at least one `x` tag matching the sha256 hash of the blob being retrieved

--- a/buds/01.md
+++ b/buds/01.md
@@ -75,7 +75,7 @@ All endpoints MUST be served from the root of the domain (eg. the `/upload` endp
 
 ## GET /sha256 - Get Blob
 
-The `GET /<sha256>` endpoint MUST return the contents of the blob in the response body. the `Content-Type` header SHOULD beset to the appropriate MIME-type
+The `GET /<sha256>` endpoint MUST return the contents of the blob in the response body. the `Content-Type` header SHOULD be set to the appropriate MIME-type
 
 The endpoint MUST accept an optional file extension in the URL. ie. `.pdf`, `.png`, etc
 

--- a/buds/02.md
+++ b/buds/02.md
@@ -53,12 +53,12 @@ servers may rely on the file extension to serve the blob correctly.
 
 ### Upload Authorization (Optional)
 
-Servers MAY accept an authorization event when uploading blobs and SHOULD perform additional checks
+Servers MAY accept an authentication event when uploading blobs and SHOULD perform additional checks
 
 1. The `t` tag MUST be set to `upload`
-2. The authorization event MUST contain at least one `x` tag matching the sha256 hash of the body of the request
+2. The authentication event MUST contain at least one `x` tag matching the sha256 hash of the body of the request
 
-Example Authorization event:
+Example Authentication event:
 
 ```json
 {
@@ -90,11 +90,11 @@ Servers MAY reject a list request for any reason and MUST respond with the appro
 
 The server MAY optionally require Authorization when listing blobs uploaded by the pubkey
 
-In this case the server MUST perform additional checks on the authorization event
+In this case the server MUST perform additional checks on the authentication event
 
 1. The `t` tag MUST be set to `list`
 
-Example Authorization event:
+Example Authentication event:
 
 ```json
 {
@@ -119,18 +119,18 @@ Servers MAY reject a delete request for any reason and SHOULD respond with the a
 
 ### Delete Authorization (required)
 
-Servers MUST accept an authorization event when deleting blobs
+Servers MUST accept an authentication event when deleting blobs
 
-Servers SHOULD perform additional checks on the authorization event
+Servers SHOULD perform additional checks on the authentication event
 
 1. The `t` tag MUST be set to `delete`
-2. The authorization event MUST contain at least one `x` tag matching the sha256 hash of the blob being deleted
+2. The authentication event MUST contain at least one `x` tag matching the sha256 hash of the blob being deleted
 
-When multiple `x` tags are present on the authorization event the server MUST only delete the blob listed in the URL.
+When multiple `x` tags are present on the authentication event the server MUST only delete the blob listed in the URL.
 
 **Multiple `x` tags MUST NOT be interpreted as the user requesting a bulk delete.**
 
-Example Authorization event:
+Example Authentication event:
 
 ```json
 {

--- a/buds/04.md
+++ b/buds/04.md
@@ -19,11 +19,11 @@ Clients MUST pass the URL of the remote blob as a stringified JSON object in the
 }
 ```
 
-Clients MAY set the `Authorization` header to an upload authorization event defined in [BUD-02](./02.md#upload-authorization-optional). When using authorization, the event MUST be of type "upload".
+Clients MAY set the `Authorization` header to an upload authentication event defined in [BUD-02](./02.md#upload-authorization-optional). When using authorization, the event MUST be of type "upload".
 
-The `/mirror` endpoint MUST download the blob from the specified URL and verify that there is at least one `x` tag in the authorization event matching the sha256 hash of the download blob
+The `/mirror` endpoint MUST download the blob from the specified URL and verify that there is at least one `x` tag in the authentication event matching the sha256 hash of the download blob
 
-**Multiple `x` tags in the authorization event MUST NOT be interpreted as the user requesting to mirror multiple blobs.**
+**Multiple `x` tags in the authentication event MUST NOT be interpreted as the user requesting to mirror multiple blobs.**
 
 The endpoint MUST return a [Blob Descriptor](#blob-descriptor) and a `2xx` status code if the mirroring was successful
 or a `4xx` status code and error message if it was not.
@@ -38,9 +38,9 @@ Servers MAY reject a mirror request for any reason and MUST respond with the app
 
 ## Example Flow
 
-1. Client signs an `upload` authorization event and uploads blob to Server A
+1. Client signs an `upload` authentication event and uploads blob to Server A
 1. Server A returns a [Blob Descriptor](./02.md#blob-descriptor) with the `url`
-1. Client sends the `url` to Server B `/mirror` using the original `upload` authorization event
+1. Client sends the `url` to Server B `/mirror` using the original `upload` authentication event
 1. Server B downloads the blob from Server A using the `url`
-1. Server B verifies the downloaded blob hash matches the `x` tag in the authorization event
+1. Server B verifies the downloaded blob hash matches the `x` tag in the authentication event
 1. Server B returns a [Blob Descriptor](./02.md#blob-descriptor)

--- a/buds/05.md
+++ b/buds/05.md
@@ -18,9 +18,9 @@ Servers MAY reject media uploads for any reason and should respond with the appr
 
 ### Upload Authorization
 
-Servers MAY require a `media` [authorization event](./02.md#upload-authorization-required) to identify the uploader
+Servers MAY require a `media` [authentication event](./02.md#upload-authorization-required) to identify the uploader
 
-If a server requires a `media` authorization event it MUST perform the following checks
+If a server requires a `media` authentication event it MUST perform the following checks
 
 1. The `t` tag MUST be set to `media`
 2. MUST contain at least one `x` tag matching the sha256 hash of the body of the request
@@ -45,4 +45,4 @@ Clients MAY let a user selected a "trusted processing" server for uploading imag
 
 Once a server has been selected, the client uploads the original media to the `/media` endpoint of the trusted server and get the optimized blob back
 
-Then the client can ask the user to sign another `upload` authorization event for the new optimized blob and call the `/mirror` endpoint on other servers to distribute the blob
+Then the client can ask the user to sign another `upload` authentication event for the new optimized blob and call the `/mirror` endpoint on other servers to distribute the blob

--- a/buds/06.md
+++ b/buds/06.md
@@ -18,7 +18,7 @@ The `HEAD /upload` endpoint MUST use the `X-SHA-256`, `X-Content-Type` and `X-Co
 
 ### Upload Authorization
 
-The `HEAD /upload` endpoint MAY accept an `upload` authorization event using the `Authorization` header similar to what is used in the [`PUT /upload`](./02.md#upload-authorization-required) endpoint
+The `HEAD /upload` endpoint MAY accept an `upload` authentication event using the `Authorization` header similar to what is used in the [`PUT /upload`](./02.md#upload-authorization-required) endpoint
 
 If the server requires authorization to upload it may respond with the `401` status code, or if authorization was provided and is invalid or not permitted it may respond with `403` status code
 


### PR DESCRIPTION
This PR aims to clarity auth.

## Authentication vs Authorization

First, it renames Authorization events to Authentication events because:
1. The event is used by the Server to identify the Client with a Nostr pubkey, but has nothing to do with whether the Client is allowed to perform that action.
2. It aligns with the [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md)

I think NIP-98 is also wrong so I'll make a PR there as well (after hearing feedback here).

| /                 | Authentication | Authorization |
| -------------- | ---------------------  | -------------------- |
| Question  | Who are you?    | Are you allowed? |
| Specificity | Protocol specific | Implementation specific |

## Server URL Commitment

@hzrd149, as far as I've read the `GET /<sha256>` authentication flow is the only one that CAN accept a server tag containing the full server URL.

> The event MUST contain either a server tag containing the full URL to the server or MUST contain at least one x tag matching the sha256 hash of the blob being retrieved

This is in contrast to a previous paragraph

> Authorization events must be generic and must NOT be scoped to specific servers. This allows pubkeys to sign a single event and interact the same way with multiple servers.

I think the protocol should choose between always requiring the full URL like NIP-42 and NIP-98, or avoid it altogether.
I think the best way would be to always require the url, even though this comes at the cost of the client having to sign more events.

The reason is to have stronger authentication guarantees.
Let's consider this example:

- Alice sends a `DELETE /sha256` to Server A. She doesn't want Server A to host her blob anymore.
- The request correctly contains the Authentication event signed by Alice's key.
- Server A is malicious. Before event expiration, the server impersonates Alice with the blossom servers in her nostr list, and deletes her blob from all.