### PR TITLE
Remove list endpoint

### DIFF
--- a/buds/02.md
+++ b/buds/02.md
@@ -6,7 +6,7 @@
 
 _All pubkeys MUST be in hex format_
 
-Defines the `/upload`, `/list` and `DELETE /<sha256>` endpoints
+Defines the `/upload` and `DELETE /<sha256>` endpoints
 
 ## Blob Descriptor
 
@@ -51,22 +51,6 @@ When storing blobs, servers MAY normalise the file extension to a standard forma
 ### Upload Authorization (Optional)
 
 Servers MAY require authorization when uploading blobs, as defined by [BUD-11](./11.md#endpoint-authorization-requirements).
-
-## GET /list/pubkey - List Blobs (Unrecommended)
-
-**Note:** The `/list` endpoint is optional and unrecommended. It is not necessary for all servers to implement the `/list` endpoint. Servers MAY implement this endpoint, but are not required to do so.
-
-The `/list/<pubkey>` endpoint MUST return a JSON array of [Blob Descriptor](#blob-descriptor) that were uploaded by the specified pubkey
-
-The endpoint MUST support `cursor` and `limit` query parameters for cursor based pagination. The `cursor` parameter MUST be the `sha256` hash of the last blob in the previous page, or omitted to request the first page. The `limit` parameter specifies the maximum number of results to return. The returned array of blob descriptors MUST be sorted by the `uploaded` date in descending order and MUST NOT include the blob at the cursor
-
-The endpoint MAY support `since` and `until` query parameters to filter the list of blobs by their `uploaded` date. These parameters are deprecated for pagination purposes as they do not preserve server resources
-
-Servers MAY reject a list request for any reason and MUST respond with the appropriate HTTP `4xx` status code and an error message explaining the reason for the rejection
-
-### List Authorization
-
-Servers MAY require authorization when listing blobs as defined by [BUD-11](./11.md#endpoint-authorization-requirements).
 
 ## DELETE /sha256 - Delete Blob
 


### PR DESCRIPTION
Blossom server should not be keeping track of a users blobs for them. nor should users be trusting blossom servers (that will eventually go offline) to keep a list of the blobs they uploaded. Instead users should be tracking this themself and storing it in local databases or as nostr events on relays