### PR TITLE
Require X-SHA-256 header on uploads

### DIFF
--- a/buds/02.md
+++ b/buds/02.md
@@ -39,7 +39,7 @@ Example:
 The `PUT /upload` endpoint MUST accept binary data in the request body.  
 The server MUST NOT modify the blob in any way and MUST compute the sha256 hash over the exact bytes received. This requirement ensures that users can re-upload blobs to other servers without discrepancies.
 
-Clients SHOULD include `Content-Type` and `Content-Length` headers specifying the MIME type and size of the data. Clients MAY provide an `X-SHA-256` header containing the lowercase hex-encoded sha256 of the request body. A server MAY use this value to enforce rejection policies or perform authorization checks prior to persisting the blob.
+Clients SHOULD include `Content-Type` and `Content-Length` headers specifying the MIME type and size of the data. Clients MUST provide an `X-SHA-256` header containing the lowercase hex-encoded sha256 of the request body. A server MUST use this value to enforce rejection policies or perform authorization checks prior to persisting the blob, and MAY reject requests missing this header with a `400 Bad Request` status code.
 
 On success, the endpoint MUST respond with a `2xx` status code with a [Blob Descriptor](#blob-descriptor) in the response body.  
 On failure, the endpoint MUST return an appropriate `4xx` status code and an error message explaining the reason for the rejection.

--- a/buds/05.md
+++ b/buds/05.md
@@ -11,7 +11,7 @@ Defines the `PUT /media` endpoint for processing and optimizing media
 The `PUT /media` endpoint MUST accept binary data in the request body.  
 The server SHOULD perform any optimizations or conversions it deems necessary in order to make the media more suitable for distribution.
 
-Clients SHOULD include `Content-Type` and `Content-Length` headers specifying the MIME type and size of the data. Clients MAY provide an `X-SHA-256` header containing the lowercase hex-encoded sha256 of the request body. A server MAY use this value to enforce rejection policies or perform authorization checks prior to persisting the blob.
+Clients SHOULD include `Content-Type` and `Content-Length` headers specifying the MIME type and size of the data. Clients MUST provide an `X-SHA-256` header containing the lowercase hex-encoded sha256 of the request body. A server MUST use this value to enforce rejection policies or perform authorization checks prior to persisting the blob, and MAY reject requests missing this header with a `400 Bad Request` status code.
 
 On success, the endpoint MUST respond with a `2xx` status code with a [Blob Descriptor](#blob-descriptor) in the response body.  
 On failure, the endpoint MUST return an appropriate `4xx` status code and an error message explaining the reason for the rejection.
@@ -22,7 +22,7 @@ Servers MAY require authorization when processing media as defined by [BUD-11](.
 
 ## HEAD /media
 
-Servers MUST respond to `HEAD` requests on the `/media` endpoint in a similar way to the `HEAD /upload` endpoint defined in [BUD-06](./06.md)
+Servers MUST respond to `HEAD` requests on the `/media` endpoint following the same rules as the `HEAD /upload` endpoint defined in [BUD-06](./06.md). Clients MUST include the `X-SHA-256`, `X-Content-Type`, and `X-Content-Length` headers when making a `HEAD /media` request.
 
 ## Limitations
 

--- a/buds/06.md
+++ b/buds/06.md
@@ -12,6 +12,8 @@ The `HEAD /upload` endpoint MUST use the `X-SHA-256`, `X-Content-Type` and `X-Co
 
 ### Headers
 
+Clients MUST include the following headers in the request:
+
 - `X-SHA-256`: A lowercase hex-encoded sha256 string that represents the blob's hash.
 - `X-Content-Length`: An integer that represents the blob size in bytes.
 - `X-Content-Type`: A string that specifies the blob's MIME type, like `application/pdf` or `image/png`.


### PR DESCRIPTION
Servers need to fail fast on uploads and with the `X-SHA-256` header being optional clients cant know if the header is required by the server or not.

This is a breaking change to require clients to send the `X-SHA-256` header when uploading blobs to servers