### PR TITLE
BUD-12: Identical Media Deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ BUDs or **Blossom Upgrade Documents** are short documents that outline an additi
 - [BUD-09: Blob Report](./buds/09.md)
 - [BUD-10: Blossom URI Schema](./buds/10.md)
 - [BUD-11: Nostr Authorization](./buds/11.md)
+- [BUD-12: Identical Media Deduplication](./buds/12.md)
 
 ## Endpoints
 

--- a/buds/12.md
+++ b/buds/12.md
@@ -1,0 +1,83 @@
+# BUD-12
+
+## Identical Media Deduplication
+
+`draft` `optional`
+
+Defines a mechanism for servers to detect and redirect clients away from uploading media that is identical to content already stored on the server under a different SHA-256 hash. This reduces redundant storage of equivalent content while preserving full backwards compatibility.
+
+## Motivation
+
+Because Blossom addresses blobs by their exact SHA-256 hash, two images that are visually indistinguishable but differ by even a single byte (e.g. different EXIF metadata, re-encoding artifacts, slight compression differences) are treated as entirely distinct blobs. This leads to servers accumulating large numbers of near-duplicate media files. This BUD provides a standard way for servers to signal to clients that an equivalent blob already exists and should be used instead.
+
+How a server determines whether two blobs are identical is an implementation detail left entirely to the server. This BUD only standardizes the response format.
+
+Some examples of approaches servers MAY use:
+
+- **pHash (DCT perceptual hash)** — a 64-bit hash derived from the frequency domain of an image; two images with a Hamming distance below a chosen threshold are considered identical. Well-suited for images and video keyframes.
+- **Chromaprint** — an acoustic fingerprint algorithm suited for audio files.
+- **SSIM / MS-SSIM** — structural similarity metrics that compare luminance, contrast, and structure between images.
+- **Normalized SHA-256** — stripping metadata (e.g. EXIF) before hashing, for an exact-match approach that is cheaper to compute.
+- **Machine learning embeddings** — computing vector embeddings and comparing cosine similarity, useful for semantic deduplication across different crops or aspect ratios.
+
+## X-Identical-Media Response Header
+
+When a server determines that an uploaded or pre-checked blob is identical to an existing blob, it MUST include the following response header:
+
+```
+X-Identical-Media: <sha256>
+```
+
+Where `<sha256>` is the lowercase hex-encoded SHA-256 hash of the existing blob that the server considers identical.
+
+Servers SHOULD also include `X-Reason` with a human-readable explanation.
+
+## Server Behavior
+
+### During PUT /upload (BUD-02)
+
+If a server receives a blob upload and determines that the blob is identical to an existing blob, the server:
+
+- MUST return `409 Conflict`
+- MUST include `X-Identical-Media: <sha256>` with the hash of the existing equivalent blob
+- SHOULD include `X-Reason` with a human-readable message
+- MUST NOT store the newly uploaded blob
+
+Example:
+
+```http
+HTTP/1.1 409 Conflict
+X-Identical-Media: b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553
+X-Reason: An identical image already exists on this server. Use the hash above to mirror it to other servers.
+```
+
+### During PUT /media (BUD-05)
+
+Servers implementing the `/media` optimization endpoint MAY also apply identical media detection on the optimized output before storing. If the optimized result is identical to an existing blob, the server SHOULD return `409 Conflict` with `X-Identical-Media`.
+
+## Client Behavior
+
+Clients receiving a `409 Conflict` response with an `X-Identical-Media` header:
+
+- MUST treat the response as a rejection of the upload
+- SHOULD treat the value of `X-Identical-Media` as the canonical SHA-256 hash to use in place of the uploaded blob
+- SHOULD use the returned hash for any Nostr event metadata (e.g. NIP-94 `x` tag, NIP-92 `imeta` tag)
+- SHOULD mirror the existing blob to other servers using `PUT /mirror` (BUD-04) with the returned hash rather than re-uploading the original file
+- MAY inform the user that an equivalent file was already available
+
+### Example Client Flow
+
+1. Client attempts `PUT /upload` with a new image
+2. Server responds `409 Conflict` with `X-Identical-Media: <existing-sha256>`
+3. Client discards the upload and uses `<existing-sha256>` as the blob reference
+4. Client calls `PUT /mirror` on other target servers using the URL of the existing blob (resolved from the responding server)
+
+## Backwards Compatibility
+
+Clients that do not implement this BUD will receive a `409 Conflict` HTTP status code, which they MUST treat as an upload failure. Such clients will not be able to recover the equivalent blob hash automatically, but the response does not break any existing protocol behavior. Servers that do not implement this BUD will accept all uploads normally.
+
+## Security and Privacy Considerations
+
+- Identical media detection is performed server-side; clients never send a perceptual hash or similarity fingerprint
+- Servers MUST NOT use this mechanism to fingerprint or surveil users; the `X-Identical-Media` response header only discloses that an equivalent blob exists, not who uploaded it or when
+- A malicious client cannot use this mechanism to probe for the existence of specific content, since no query endpoint is defined — detection is only triggered during an upload attempt

--- a/buds/12.md
+++ b/buds/12.md
@@ -43,6 +43,8 @@ If a server receives a blob upload and determines that the blob is identical to 
 - SHOULD include `X-Reason` with a human-readable message
 - MUST NOT store the newly uploaded blob
 
+If the upload request includes `X-Identical-Media: <sha256>` matching an existing blob, the server MAY skip identical media detection and proceed with storing the blob normally.
+
 Example:
 
 ```http
@@ -55,6 +57,18 @@ X-Reason: An identical image already exists on this server. Use the hash above t
 
 Servers implementing the `/media` optimization endpoint MAY also apply identical media detection on the optimized output before storing. If the optimized result is identical to an existing blob, the server SHOULD return `409 Conflict` with `X-Identical-Media`.
 
+## Acknowledging Identical Media
+
+Clients MAY include the `X-Identical-Media` request header to acknowledge a previously received deduplication response and force the server to store the blob regardless:
+
+```
+X-Identical-Media: <sha256>
+```
+
+Where `<sha256>` is the hash returned by the server in a prior `409 Conflict` response. This signals that the client is aware of the existing equivalent blob and is intentionally uploading a distinct copy.
+
+When a server receives a request with `X-Identical-Media` matching an existing blob, it MAY skip identical media detection and proceed with storing the blob normally, responding with `200 OK` as defined by BUD-02. Servers MAY still return `409 Conflict` if they choose not to allow duplicate uploads regardless of client acknowledgement.
+
 ## Client Behavior
 
 Clients receiving a `409 Conflict` response with an `X-Identical-Media` header:
@@ -64,6 +78,7 @@ Clients receiving a `409 Conflict` response with an `X-Identical-Media` header:
 - SHOULD use the returned hash for any Nostr event metadata (e.g. NIP-94 `x` tag, NIP-92 `imeta` tag)
 - SHOULD mirror the existing blob to other servers using `PUT /mirror` (BUD-04) with the returned hash rather than re-uploading the original file
 - MAY inform the user that an equivalent file was already available
+- MAY retry the upload with `X-Identical-Media: <sha256>` (echoing the returned hash) if the user explicitly requests uploading a distinct copy
 
 ### Example Client Flow
 
@@ -71,6 +86,14 @@ Clients receiving a `409 Conflict` response with an `X-Identical-Media` header:
 2. Server responds `409 Conflict` with `X-Identical-Media: <existing-sha256>`
 3. Client discards the upload and uses `<existing-sha256>` as the blob reference
 4. Client calls `PUT /mirror` on other target servers using the URL of the existing blob (resolved from the responding server)
+
+### Example Acknowledged Upload Flow
+
+1. Client attempts `PUT /upload` with a new image
+2. Server responds `409 Conflict` with `X-Identical-Media: <existing-sha256>`
+3. User explicitly requests to upload a distinct copy regardless
+4. Client retries `PUT /upload` with `X-Identical-Media: <existing-sha256>` echoed back in the request
+5. Server recognises the acknowledgement, skips deduplication, and responds `200 OK` with the new blob's descriptor
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Summary

- Adds BUD-12, a new optional spec for servers to detect and reject uploads of media identical to an already-stored blob
- Servers respond with `409 Conflict` and an `X-Identical-Media: <sha256>` header pointing to the existing equivalent blob
- Detection method is left entirely to the server implementation (perceptual hashing, normalized hash, ML embeddings, etc.)
- Clients receiving the response should use the returned hash as the canonical reference and mirror it to other servers via BUD-04 rather than re-uploading
- Fully backwards compatible: clients that don't implement BUD-12 simply see a `409` upload failure