### PR TITLE
BUD-01: Sunset header for blob expiration

### DIFF
--- a/buds/01.md
+++ b/buds/01.md
@@ -67,3 +67,22 @@ The endpoint MUST accept an optional file extension in the URL similar to the `G
 To better support mobile devices, video files, or low bandwidth connections. servers should support range requests ([RFC 7233 section 3](https://www.rfc-editor.org/rfc/rfc7233#section-3)) on the `GET /<sha256>` endpoint and signal support using the `accept-ranges: bytes` and `content-length` headers on the `HEAD /<sha256>` endpoint
 
 See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) for more details
+
+## Sunset Header (Optional)
+
+Servers MAY include the [`Sunset`](https://www.rfc-editor.org/rfc/rfc8594.html) HTTP response header on `GET /<sha256>` and `HEAD /<sha256>` responses to indicate that a blob is expected to become unavailable at a specific time due to server retention, expiration, or automatic deletion policy.
+
+Clients SHOULD treat the `Sunset` value as advisory only. It indicates expected future unavailability of the blob resource, but it does not guarantee that the blob will be deleted at that exact time or that it will remain unavailable forever.
+
+Clients MUST NOT interpret `Sunset` as a permanent negative cache signal. After the advertised time, the definitive test of whether a blob is still available is to request `GET /<sha256>` or `HEAD /<sha256>` again.
+
+Because Blossom blobs are addressed by sha256, the same blob MAY become available again at the same path if a server later re-imports, restores, or re-uploads it. Clients MUST NOT assume that a previously observed `Sunset` header means the blob can never reappear.
+
+After the `Sunset` time, servers MAY respond according to their own policy, including `404 Not Found`, `410 Gone`, or a redirection response.
+
+Example:
+
+```http
+HTTP/1.1 200 OK
+Sunset: Wed, 11 Nov 2026 11:11:11 GMT
+```


### PR DESCRIPTION
Add an optional section to BUD-01 that recommends the use of the `Sunset` header for servers to signal to clients when a blob with become unavailable

[Readable version](https://github.com/hzrd149/blossom/blob/sunset-header/buds/01.md)