### PR TITLE
Use HTTP Link header for blob previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ BUDs or **Blossom Upgrade Documents** are short documents that outline an additi
 - [BUD-09: Blob Report](./buds/09.md)
 - [BUD-10: Blossom URI Schema](./buds/10.md)
 - [BUD-11: Nostr Authorization](./buds/11.md)
+- [BUD-14: Blob Previews](./buds/14.md)
 
 ## Endpoints
 

--- a/buds/14.md
+++ b/buds/14.md
@@ -1,0 +1,50 @@
+# BUD-14
+
+## Blob Previews
+
+`draft` `optional`
+
+Defines how Blossom servers can advertise preview images for blobs using the HTTP `Link` response header as specified by [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html).
+
+## Preview discovery
+
+On successful `HEAD /<sha256>` and `GET /<sha256>` responses, servers MAY include a `Link` response header with `rel="preview"` to advertise a preview representation of the blob.
+
+Example:
+
+```http
+HEAD /b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf HTTP/1.1
+
+HTTP/1.1 200 OK
+Content-Type: application/pdf
+Content-Length: 184292
+Link: </thumbnails/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.jpg>; rel="preview"
+```
+
+The link target MAY be an absolute URL or a relative reference resolved according to [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html).
+
+## Preview representation
+
+The link target identifies a preview representation of the blob.
+
+The preview representation SHOULD be returned as an `image/*` resource.
+
+The preview URL is implementation-defined and is not required to be a Blossom blob URL or any other [BUD-01](./01.md) endpoint.
+
+Servers MAY generate previews eagerly, lazily, or on demand.
+
+Servers MAY omit the `Link` header when no preview is available.
+
+## Client behavior
+
+Clients SHOULD use `HEAD /<sha256>` to discover previews without downloading the original blob.
+
+Clients MAY also inspect `GET /<sha256>` responses for the same `Link` header.
+
+Clients MUST NOT assume the preview URL can be derived from the blob URL.
+
+Clients SHOULD treat the preview as an optional hint and fall back gracefully when the `Link` header is absent or the preview resource cannot be fetched.
+
+## Notes
+
+Servers MAY also expose the same preview URL using the NIP-94 `thumb` tag described in [BUD-08](./08.md).


### PR DESCRIPTION
Inspired by #57 and https://www.rfc-editor.org/rfc/rfc8288.html

The PR adds support for servers specifying a "preview" URL to a blob using the `Link` header on `HEAD /<sha256>` and `GET <sha256>` endpoints

[Readable version](https://github.com/hzrd149/blossom/blob/blob-previews/buds/14.md)