### PR TITLE
BUD-15: Client-side CHK encrypted blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ BUDs or **Blossom Upgrade Documents** are short documents that outline an additi
 - [BUD-10: Blossom URI Schema](./buds/10.md)
 - [BUD-11: Nostr Authorization](./buds/11.md)
 - [BUD-12: Blob management endpoints](./buds/12.md)
+- [BUD-15: Client-side CHK encrypted blobs](./buds/15.md)
 
 ## Endpoints
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -1,6 +1,6 @@
 # BUD-15
 
-## Client-side CHK encrypted blobs
+## Client-side Content Hash Key encrypted blobs
 
 `draft` `optional`
 
@@ -12,7 +12,7 @@ Servers do not implement this BUD. Clients upload ciphertext as normal Blossom b
 
 Random encryption gives the same file a new ciphertext every time.
 
-CHK gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, block lists, and moderation based on stable blob hashes useful even when the hosted bytes are encrypted.
+Content Hash Key (CHK) gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, block lists, and moderation based on stable blob hashes useful even when the hosted bytes are encrypted.
 
 Servers still receive only ciphertext and MAY apply any policy they choose.
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -47,6 +47,8 @@ After fetching ciphertext, clients MUST:
 2. Decrypt the response body using the CHK key and the `chk-v1` algorithm.
 3. Verify `SHA256(plaintext)` matches the CHK key.
 
+The final check confirms that the supplied CHK key is actually the plaintext content hash. AES-GCM authentication alone only confirms that the ciphertext decrypts under a key derived from the supplied CHK key.
+
 If any validation step fails, clients MUST treat the blob as invalid.
 
 Because `chk-v1` encrypts one complete plaintext into one complete AES-GCM record, clients generally need the complete ciphertext and authentication tag before plaintext can be authenticated. For large or streamable content, clients SHOULD use a higher-level chunked format where each chunk is independently CHK encrypted and addressed as its own Blossom blob.

--- a/buds/15.md
+++ b/buds/15.md
@@ -4,112 +4,83 @@
 
 `draft` `optional`
 
-This document defines a deterministic client-side encryption format for storing encrypted bytes on Blossom servers while keeping Blossom's existing content-addressed blob model intact.
+This document defines `chk-v1`, a deterministic client-side encryption format for Blossom blobs.
 
-A CHK encrypted blob is uploaded, stored, fetched, mirrored, and deleted as an ordinary Blossom blob. The `sha256` used in Blossom endpoints is always the hash of the exact stored bytes, which are the ciphertext bytes for encrypted blobs.
-
-This BUD does not define any new server requirements. Blossom servers do not need to implement BUD-15, recognize CHK encrypted blobs, or learn any decryption key. Clients and higher-level protocols implement this BUD by encrypting before upload and decrypting after download.
+Servers do not implement this BUD. Clients upload ciphertext as normal Blossom blobs.
 
 ## Terms
 
-- **Plaintext** is the original byte sequence before encryption.
-- **Ciphertext** is the encrypted byte sequence stored on Blossom servers, including the AES-GCM authentication tag.
-- **Blob hash** is `SHA256(ciphertext)` and is used in `GET /<sha256>`, `HEAD /<sha256>`, `DELETE /<sha256>`, `X-SHA-256`, and `blossom:` URIs.
-- **CHK key** is `SHA256(plaintext)` and is required to decrypt the ciphertext.
+- `plaintext`: bytes before encryption.
+- `ciphertext`: encrypted bytes stored as the Blossom blob, including the AES-GCM tag.
+- `blob_hash`: `SHA256(ciphertext)`.
+- `chk_key`: `SHA256(plaintext)`.
 
-## CHK Encryption
+## Encryption
 
-Clients MUST use the following algorithm for `chk-v1`:
+To encrypt:
 
 1. Compute `chk_key = SHA256(plaintext)`.
 2. Derive `aes_key = HKDF-SHA256(ikm = chk_key, salt = "hashtree-chk", info = "encryption-key", length = 32)`.
-3. Encrypt the plaintext with AES-256-GCM using `aes_key` and a 12 byte nonce of all zero bytes.
-4. Store the result as `ciphertext`, which is the AES-GCM ciphertext followed by the 16 byte authentication tag.
-5. Compute `blob_hash = SHA256(ciphertext)`.
+3. Encrypt `plaintext` with AES-256-GCM using `aes_key` and a 12 byte zero nonce.
+4. Store `ciphertext = aes_gcm_ciphertext || 16_byte_tag`.
+5. Address the blob by `blob_hash = SHA256(ciphertext)`.
 
-The CHK key is the plaintext hash, not the AES-GCM key. Clients MUST derive the AES-GCM key using HKDF before encryption or decryption.
+Writers MUST derive `chk_key` from the plaintext. They MUST NOT use arbitrary keys with the zero nonce.
 
-The zero nonce is only valid for this CHK construction because the encryption key is derived from the plaintext. Writers MUST derive `chk_key` from the plaintext for each encryption and MUST NOT use an arbitrary externally supplied key. Reusing the same derived AES-GCM key with the zero nonce for different plaintexts breaks AES-GCM nonce uniqueness.
+If `X-SHA-256` is sent on upload, it MUST be `blob_hash`, not `chk_key`.
 
-## Uploads
+## Decryption
 
-Clients upload the ciphertext bytes using [BUD-02](./02.md#put-upload---upload-blob) `PUT /upload` or another compatible Blossom upload endpoint.
+To decrypt:
 
-If the client includes `X-SHA-256`, it MUST be the lowercase hex encoded `SHA256(ciphertext)`, not `SHA256(plaintext)`.
+1. Verify `SHA256(ciphertext) == blob_hash`.
+2. Derive `aes_key` from `chk_key`.
+3. AES-GCM decrypt with the zero nonce.
+4. Verify `SHA256(plaintext) == chk_key`.
 
-Clients SHOULD use `Content-Type: application/octet-stream` for CHK encrypted uploads unless they have a specific reason to expose that the stored bytes are encrypted. Plaintext MIME type and filename metadata SHOULD be shared outside the raw Blossom upload, for example in a `blossom:` URI extension, Nostr event, or higher-level manifest.
+If any step fails, clients MUST reject the blob.
 
-## Downloads
-
-After fetching ciphertext, clients MUST:
-
-1. Verify `SHA256(response_body)` matches the requested blob hash.
-2. Decrypt the response body using the CHK key and the `chk-v1` algorithm.
-3. Verify `SHA256(plaintext)` matches the CHK key.
-
-AES-GCM authentication confirms that the ciphertext decrypts under a key derived from the supplied CHK key. The final check confirms that the supplied CHK key is actually the plaintext content hash, which is required by `chk-v1`.
-
-If any validation step fails, clients MUST treat the blob as invalid.
-
-Because `chk-v1` encrypts one complete plaintext into one complete AES-GCM record, clients generally need the complete ciphertext and authentication tag before plaintext can be authenticated. For large or streamable content, clients SHOULD use a higher-level chunked format where each chunk is independently CHK encrypted and addressed as its own Blossom blob.
+For large or streamable content, encrypt each chunk separately.
 
 ## Blossom URI Parameters
 
-[BUD-10](./10.md) `blossom:` URIs MAY include the following query parameters for CHK encrypted blobs:
+`blossom:` URIs MAY include:
 
-### `enc` - Encryption Scheme
+- `enc=chk-v1`
+- `k=<chk_key>` as 64 lowercase hex characters
+- `sz=<ciphertext_size>`
 
-The `enc` parameter identifies the encryption scheme. For this BUD, the value MUST be `chk-v1`.
+If `k` is present, `enc=chk-v1` MUST also be present.
 
-If a URI includes `k`, it MUST also include `enc=chk-v1`. If a URI includes `enc=chk-v1` without `k`, clients MAY fetch the ciphertext but cannot decrypt it using this BUD.
+`k` is a bearer secret. Clients MUST NOT send it to Blossom servers.
 
-### `k` - CHK Key
+For `chk-v1`, plaintext size is `sz - 16` when `sz` is present. If `sz < 16`, the URI is invalid.
 
-The `k` parameter contains the lowercase hex encoded CHK key. It MUST be exactly 64 hexadecimal characters.
-
-Clients MUST treat `k` as a bearer secret. Anyone who has both the blob hash and `k` can decrypt the blob.
-
-### Size
-
-The existing BUD-10 `sz` parameter continues to describe the stored Blossom blob size. For CHK encrypted blobs, `sz` is the ciphertext size, including the 16 byte authentication tag.
-
-Because `chk-v1` does not prefix a nonce or any other bytes, clients MAY derive the plaintext size as `sz - 16` when `sz` is present. If `sz` is less than `16`, clients MUST treat the URI as invalid.
-
-### URI Example
-
-For plaintext `hello`:
-
-- CHK key: `2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824`
-- Ciphertext: `c65308d9c8649ff1c59820d0b3a030db34ad00f92d`
-- Blob hash: `70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461`
+Example for plaintext `hello`:
 
 ```text
 blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc=chk-v1&k=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824&sz=21
 ```
 
-When resolving this URI, clients MUST request the blob by `blob_hash`. Clients MUST NOT forward the `k` parameter to Blossom servers when constructing HTTP requests. Clients also SHOULD NOT forward `enc` unless a future HTTP endpoint explicitly defines that parameter.
-
-The file extension in a CHK `blossom:` URI SHOULD describe the decrypted plaintext. The HTTP response from the Blossom server describes the ciphertext object and MAY use `application/octet-stream`.
+The extension SHOULD describe the plaintext.
 
 ## Rationale
 
-Randomized encryption produces different ciphertext each time the same file is uploaded. That makes encrypted blob hosting harder for Blossom servers because duplicate encrypted uploads cannot be recognized by ordinary blob hash, and hash-based caching, quotas, allow lists, block lists, and moderation tools become less useful.
+Random encryption gives the same file a new ciphertext every time.
 
-CHK encryption is deterministic. The same plaintext always produces the same CHK key, ciphertext, and Blossom blob hash. This preserves Blossom's content-addressed behavior even when servers host only encrypted bytes.
+CHK gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, block lists, and moderation based on stable blob hashes useful even when the hosted bytes are encrypted.
 
-For servers that allow encrypted blobs, this reduces moderation and storage burden compared to randomized per-upload encryption. Servers can apply their existing policies to stable ciphertext hashes without receiving plaintext or decryption keys. Servers MAY still reject encrypted blobs, require additional policy signals, or moderate by any other mechanism they support.
+Servers still receive only ciphertext and MAY apply any policy they choose.
 
-## Security Considerations
+## Security
 
-The deterministic property described above reveals equality of plaintexts to anyone who can observe blob hashes or ciphertext.
+CHK reveals plaintext equality to anyone who can observe blob hashes or ciphertext.
 
-CHK encryption is vulnerable to confirmation attacks for guessable plaintext. An attacker who can guess the plaintext can compute the CHK ciphertext and check whether the corresponding blob exists. Clients SHOULD avoid using CHK alone for low-entropy secrets or content where equality leakage is unacceptable.
+CHK is vulnerable to confirmation attacks for guessable plaintext. Do not use CHK alone for low-entropy secrets or content where equality leakage is unacceptable.
 
-The CHK key MUST be protected like any other decryption key. It SHOULD NOT be sent to Blossom servers, logged, indexed publicly, or included in ordinary HTTP URLs that will be fetched by generic HTTP clients.
+Protect `k` like any decryption key.
 
 ## Reference Implementation
-
-The Hashtree project includes a reference implementation of `chk-v1` and interoperable test vectors:
 
 ```text
 https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree

--- a/buds/15.md
+++ b/buds/15.md
@@ -27,8 +27,6 @@ To encrypt:
 
 Writers MUST derive `chk_key` from the plaintext. They MUST NOT use arbitrary keys with the zero nonce.
 
-If `X-SHA-256` is sent on upload, it MUST be `blob_hash`, not `chk_key`.
-
 ## Decryption
 
 To decrypt:

--- a/buds/15.md
+++ b/buds/15.md
@@ -1,6 +1,6 @@
 # BUD-15
 
-## Client-side Content Hash Key encrypted blobs
+## Client-side Content Hash Key (CHK) encrypted blobs
 
 `draft` `optional`
 
@@ -12,9 +12,9 @@ Servers do not implement this BUD. Clients upload ciphertext as normal Blossom b
 
 Random encryption gives the same file a new ciphertext every time.
 
-Content Hash Key (CHK) gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, block lists, and moderation based on stable blob hashes useful even when the hosted bytes are encrypted.
+Content Hash Key (CHK) gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, and block lists useful for encrypted blobs.
 
-Servers still receive only ciphertext and MAY apply any policy they choose.
+A server or P2P peer can choose to store only encrypted content. Since it never receives plaintext, moderation can be limited to stable ciphertext hashes and bytes, reducing the burden of hosting encrypted content.
 
 ## Terms
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -71,11 +71,11 @@ The `k` parameter contains the lowercase hex encoded CHK key. It MUST be exactly
 
 Clients MUST treat `k` as a bearer secret. Anyone who has both the blob hash and `k` can decrypt the blob.
 
-### `psz` - Plaintext Size
-
-The `psz` parameter MAY contain the plaintext size in bytes. If present, clients SHOULD verify that the decrypted plaintext length matches `psz`.
+### Size
 
 The existing BUD-10 `sz` parameter continues to describe the stored Blossom blob size. For CHK encrypted blobs, `sz` is the ciphertext size, including the 16 byte authentication tag.
+
+Because `chk-v1` does not prefix a nonce or any other bytes, clients MAY derive the plaintext size as `sz - 16` when `sz` is present. If `sz` is less than `16`, clients MUST treat the URI as invalid.
 
 ### URI Example
 
@@ -86,10 +86,10 @@ For plaintext `hello`:
 - Blob hash: `70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461`
 
 ```text
-blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc=chk-v1&k=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824&sz=21&psz=5
+blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc=chk-v1&k=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824&sz=21
 ```
 
-When resolving this URI, clients MUST request the blob by `blob_hash`. Clients MUST NOT forward the `k` parameter to Blossom servers when constructing HTTP requests. Clients also SHOULD NOT forward `enc` or `psz` unless a future HTTP endpoint explicitly defines those parameters.
+When resolving this URI, clients MUST request the blob by `blob_hash`. Clients MUST NOT forward the `k` parameter to Blossom servers when constructing HTTP requests. Clients also SHOULD NOT forward `enc` unless a future HTTP endpoint explicitly defines that parameter.
 
 The file extension in a CHK `blossom:` URI SHOULD describe the decrypted plaintext. The HTTP response from the Blossom server describes the ciphertext object and MAY use `application/octet-stream`.
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -1,0 +1,122 @@
+# BUD-15
+
+## Client-side CHK encrypted blobs
+
+`draft` `optional`
+
+This document defines a deterministic client-side encryption format for storing encrypted bytes on Blossom servers while keeping Blossom's existing content-addressed blob model intact.
+
+A CHK encrypted blob is uploaded, stored, fetched, mirrored, and deleted as an ordinary Blossom blob. The `sha256` used in Blossom endpoints is always the hash of the exact stored bytes, which are the ciphertext bytes for encrypted blobs.
+
+Servers do not need to know whether a blob is encrypted and MUST NOT be required to learn any decryption key in order to implement this BUD.
+
+## Terms
+
+- **Plaintext** is the original byte sequence before encryption.
+- **Ciphertext** is the encrypted byte sequence stored on Blossom servers, including the AES-GCM authentication tag.
+- **Blob hash** is `SHA256(ciphertext)` and is used in `GET /<sha256>`, `HEAD /<sha256>`, `DELETE /<sha256>`, `X-SHA-256`, and `blossom:` URIs.
+- **CHK key** is `SHA256(plaintext)` and is required to decrypt the ciphertext.
+
+## CHK Encryption
+
+Clients MUST use the following algorithm for `chk-v1`:
+
+1. Compute `chk_key = SHA256(plaintext)`.
+2. Derive `aes_key = HKDF-SHA256(ikm = chk_key, salt = "hashtree-chk", info = "encryption-key", length = 32)`.
+3. Encrypt the plaintext with AES-256-GCM using `aes_key` and a 12 byte nonce of all zero bytes.
+4. Store the result as `ciphertext`, which is the AES-GCM ciphertext followed by the 16 byte authentication tag.
+5. Compute `blob_hash = SHA256(ciphertext)`.
+
+The CHK key is the plaintext hash, not the AES-GCM key. Clients MUST derive the AES-GCM key using HKDF before encryption or decryption.
+
+The zero nonce is only valid for this CHK construction because the encryption key is derived from the plaintext. Implementations MUST NOT reuse this zero nonce construction with arbitrary keys or non-CHK encryption.
+
+## Uploads
+
+Clients upload the ciphertext bytes using [BUD-02](./02.md#put-upload---upload-blob) `PUT /upload` or another compatible Blossom upload endpoint.
+
+If the client includes `X-SHA-256`, it MUST be the lowercase hex encoded `SHA256(ciphertext)`, not `SHA256(plaintext)`.
+
+Clients SHOULD use `Content-Type: application/octet-stream` for CHK encrypted uploads unless they have a specific reason to expose that the stored bytes are encrypted. Plaintext MIME type and filename metadata SHOULD be shared outside the raw Blossom upload, for example in a `blossom:` URI extension, Nostr event, or higher-level manifest.
+
+Servers MUST compute and validate hashes over the exact bytes received. For CHK encrypted uploads, those bytes are ciphertext.
+
+## Downloads
+
+Clients retrieve CHK encrypted blobs using [BUD-01](./01.md#get-sha256---get-blob) `GET /<sha256>` as usual.
+
+After download, clients MUST:
+
+1. Verify `SHA256(response_body)` matches the requested blob hash.
+2. Decrypt the response body using the CHK key and the `chk-v1` algorithm.
+3. Verify `SHA256(plaintext)` matches the CHK key.
+
+If any validation step fails, clients MUST treat the blob as invalid.
+
+Because `chk-v1` encrypts one complete plaintext into one complete AES-GCM record, clients generally need the complete ciphertext and authentication tag before plaintext can be authenticated. For large or streamable content, clients SHOULD use a higher-level chunked format where each chunk is independently CHK encrypted and addressed as its own Blossom blob.
+
+## Blossom URI Parameters
+
+[BUD-10](./10.md) `blossom:` URIs MAY include the following query parameters for CHK encrypted blobs:
+
+### `enc` - Encryption Scheme
+
+The `enc` parameter identifies the encryption scheme. For this BUD, the value MUST be `chk-v1`.
+
+If a URI includes `k`, it MUST also include `enc=chk-v1`. If a URI includes `enc=chk-v1` without `k`, clients MAY fetch the ciphertext but cannot decrypt it using this BUD.
+
+### `k` - CHK Key
+
+The `k` parameter contains the lowercase hex encoded CHK key. It MUST be exactly 64 hexadecimal characters.
+
+Clients MUST treat `k` as a bearer secret. Anyone who has both the blob hash and `k` can decrypt the blob.
+
+### `psz` - Plaintext Size
+
+The `psz` parameter MAY contain the plaintext size in bytes. If present, clients SHOULD verify that the decrypted plaintext length matches `psz`.
+
+The existing BUD-10 `sz` parameter continues to describe the stored Blossom blob size. For CHK encrypted blobs, `sz` is the ciphertext size, including the 16 byte authentication tag.
+
+### URI Example
+
+For plaintext `hello`:
+
+- CHK key: `2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824`
+- Ciphertext: `c65308d9c8649ff1c59820d0b3a030db34ad00f92d`
+- Blob hash: `70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461`
+
+```text
+blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc=chk-v1&k=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824&sz=21&psz=5
+```
+
+When resolving this URI, clients MUST request the blob by `blob_hash`. Clients MUST NOT forward the `k` parameter to Blossom servers when constructing HTTP requests. Clients also SHOULD NOT forward `enc` or `psz` unless a future HTTP endpoint explicitly defines those parameters.
+
+The file extension in a CHK `blossom:` URI SHOULD describe the decrypted plaintext. The HTTP response from the Blossom server describes the ciphertext object and MAY use `application/octet-stream`.
+
+## Security Considerations
+
+CHK encryption is deterministic. The same plaintext always produces the same CHK key, ciphertext, and Blossom blob hash. This enables deduplication, but it also reveals equality of plaintexts to anyone who can observe blob hashes or ciphertext.
+
+CHK encryption is vulnerable to confirmation attacks for guessable plaintext. An attacker who can guess the plaintext can compute the CHK ciphertext and check whether the corresponding blob exists. Clients SHOULD avoid using CHK alone for low-entropy secrets or content where equality leakage is unacceptable.
+
+The CHK key MUST be protected like any other decryption key. It SHOULD NOT be sent to Blossom servers, logged, indexed publicly, or included in ordinary HTTP URLs that will be fetched by generic HTTP clients.
+
+## Test Vectors
+
+### Empty Plaintext
+
+```text
+plaintext:
+chk_key: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+ciphertext: 7cd161ae8406d82cdf553c1100d012db
+blob_hash: 346c46e7cc6722c99efe7f7bc316d8f3ff5f025f1031bf94418ef4db891e04cd
+```
+
+### `hello`
+
+```text
+plaintext: 68656c6c6f
+chk_key: 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+ciphertext: c65308d9c8649ff1c59820d0b3a030db34ad00f92d
+blob_hash: 70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461
+```

--- a/buds/15.md
+++ b/buds/15.md
@@ -33,6 +33,8 @@ To encrypt:
 4. Store `ciphertext = aes_gcm_ciphertext || 16_byte_tag`.
 5. Address the blob by `blob_hash = SHA256(ciphertext)`.
 
+AES-256-GCM is used because it is widely available in browser WebCrypto and native crypto libraries.
+
 Writers MUST derive `chk_key` from the plaintext. They MUST NOT use arbitrary keys with the zero nonce.
 
 The zero nonce is safe only because `aes_key` is derived from the plaintext, so it is never reused to encrypt two different plaintexts. Reusing a key with the zero nonce across different plaintexts leaks the XOR of those plaintexts and the GHASH authentication subkey, breaking confidentiality and allowing forgery.

--- a/buds/15.md
+++ b/buds/15.md
@@ -8,6 +8,14 @@ This document defines `chk-v1`, a deterministic client-side encryption format fo
 
 Servers do not implement this BUD. Clients upload ciphertext as normal Blossom blobs.
 
+## Rationale
+
+Random encryption gives the same file a new ciphertext every time.
+
+CHK gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, block lists, and moderation based on stable blob hashes useful even when the hosted bytes are encrypted.
+
+Servers still receive only ciphertext and MAY apply any policy they choose.
+
 ## Terms
 
 - `plaintext`: bytes before encryption.
@@ -61,14 +69,6 @@ blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc
 ```
 
 The extension SHOULD describe the plaintext.
-
-## Rationale
-
-Random encryption gives the same file a new ciphertext every time.
-
-CHK gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, block lists, and moderation based on stable blob hashes useful even when the hosted bytes are encrypted.
-
-Servers still receive only ciphertext and MAY apply any policy they choose.
 
 ## Security
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -101,6 +101,14 @@ CHK encryption is vulnerable to confirmation attacks for guessable plaintext. An
 
 The CHK key MUST be protected like any other decryption key. It SHOULD NOT be sent to Blossom servers, logged, indexed publicly, or included in ordinary HTTP URLs that will be fetched by generic HTTP clients.
 
+## Reference Implementation
+
+The Hashtree project includes a reference implementation of `chk-v1` and interoperable test vectors:
+
+```text
+https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree
+```
+
 ## Test Vectors
 
 ### Empty Plaintext

--- a/buds/15.md
+++ b/buds/15.md
@@ -12,9 +12,9 @@ Servers do not implement this BUD. Clients upload ciphertext as normal Blossom b
 
 Random encryption gives the same file a new ciphertext every time.
 
-Content Hash Key (CHK) gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, quotas, allow lists, and block lists useful for encrypted blobs.
+Content Hash Key (CHK) gives the same plaintext the same `chk_key`, ciphertext, and Blossom hash. This keeps deduplication, caching, and quota accounting useful for encrypted blobs.
 
-A server or P2P peer can choose to store only encrypted content. Since it never receives plaintext, moderation can be limited to stable ciphertext hashes and bytes, reducing the burden of hosting encrypted content.
+A server or P2P peer can choose to store only encrypted content. Since it never receives plaintext, it stores opaque ciphertext instead of readable user content and does not need to inspect hosted blobs like a plaintext media server.
 
 ## Terms
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -8,7 +8,7 @@ This document defines a deterministic client-side encryption format for storing 
 
 A CHK encrypted blob is uploaded, stored, fetched, mirrored, and deleted as an ordinary Blossom blob. The `sha256` used in Blossom endpoints is always the hash of the exact stored bytes, which are the ciphertext bytes for encrypted blobs.
 
-Servers do not need to know whether a blob is encrypted and MUST NOT be required to learn any decryption key in order to implement this BUD.
+This BUD does not define any new server requirements. Blossom servers do not need to implement BUD-15, recognize CHK encrypted blobs, or learn any decryption key. Clients and higher-level protocols implement this BUD by encrypting before upload and decrypting after download.
 
 ## Terms
 
@@ -39,13 +39,9 @@ If the client includes `X-SHA-256`, it MUST be the lowercase hex encoded `SHA256
 
 Clients SHOULD use `Content-Type: application/octet-stream` for CHK encrypted uploads unless they have a specific reason to expose that the stored bytes are encrypted. Plaintext MIME type and filename metadata SHOULD be shared outside the raw Blossom upload, for example in a `blossom:` URI extension, Nostr event, or higher-level manifest.
 
-Servers MUST compute and validate hashes over the exact bytes received. For CHK encrypted uploads, those bytes are ciphertext.
-
 ## Downloads
 
-Clients retrieve CHK encrypted blobs using [BUD-01](./01.md#get-sha256---get-blob) `GET /<sha256>` as usual.
-
-After download, clients MUST:
+After fetching ciphertext, clients MUST:
 
 1. Verify `SHA256(response_body)` matches the requested blob hash.
 2. Decrypt the response body using the CHK key and the `chk-v1` algorithm.
@@ -93,9 +89,17 @@ When resolving this URI, clients MUST request the blob by `blob_hash`. Clients M
 
 The file extension in a CHK `blossom:` URI SHOULD describe the decrypted plaintext. The HTTP response from the Blossom server describes the ciphertext object and MAY use `application/octet-stream`.
 
+## Rationale
+
+Randomized encryption produces different ciphertext each time the same file is uploaded. That makes encrypted blob hosting harder for Blossom servers because duplicate encrypted uploads cannot be recognized by ordinary blob hash, and hash-based caching, quotas, allow lists, block lists, and moderation tools become less useful.
+
+CHK encryption is deterministic. The same plaintext always produces the same CHK key, ciphertext, and Blossom blob hash. This preserves Blossom's content-addressed behavior even when servers host only encrypted bytes.
+
+For servers that allow encrypted blobs, this reduces moderation and storage burden compared to randomized per-upload encryption. Servers can apply their existing policies to stable ciphertext hashes without receiving plaintext or decryption keys. Servers MAY still reject encrypted blobs, require additional policy signals, or moderate by any other mechanism they support.
+
 ## Security Considerations
 
-CHK encryption is deterministic. The same plaintext always produces the same CHK key, ciphertext, and Blossom blob hash. This enables deduplication, but it also reveals equality of plaintexts to anyone who can observe blob hashes or ciphertext.
+The deterministic property described above reveals equality of plaintexts to anyone who can observe blob hashes or ciphertext.
 
 CHK encryption is vulnerable to confirmation attacks for guessable plaintext. An attacker who can guess the plaintext can compute the CHK ciphertext and check whether the corresponding blob exists. Clients SHOULD avoid using CHK alone for low-entropy secrets or content where equality leakage is unacceptable.
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -29,7 +29,7 @@ Clients MUST use the following algorithm for `chk-v1`:
 
 The CHK key is the plaintext hash, not the AES-GCM key. Clients MUST derive the AES-GCM key using HKDF before encryption or decryption.
 
-The zero nonce is only valid for this CHK construction because the encryption key is derived from the plaintext. Implementations MUST NOT reuse this zero nonce construction with arbitrary keys or non-CHK encryption.
+The zero nonce is only valid for this CHK construction because the encryption key is derived from the plaintext. Writers MUST derive `chk_key` from the plaintext for each encryption and MUST NOT use an arbitrary externally supplied key. Reusing the same derived AES-GCM key with the zero nonce for different plaintexts breaks AES-GCM nonce uniqueness.
 
 ## Uploads
 
@@ -47,7 +47,7 @@ After fetching ciphertext, clients MUST:
 2. Decrypt the response body using the CHK key and the `chk-v1` algorithm.
 3. Verify `SHA256(plaintext)` matches the CHK key.
 
-The final check confirms that the supplied CHK key is actually the plaintext content hash. AES-GCM authentication alone only confirms that the ciphertext decrypts under a key derived from the supplied CHK key.
+AES-GCM authentication confirms that the ciphertext decrypts under a key derived from the supplied CHK key. The final check confirms that the supplied CHK key is actually the plaintext content hash, which is required by `chk-v1`.
 
 If any validation step fails, clients MUST treat the blob as invalid.
 

--- a/buds/15.md
+++ b/buds/15.md
@@ -35,6 +35,8 @@ To encrypt:
 
 Writers MUST derive `chk_key` from the plaintext. They MUST NOT use arbitrary keys with the zero nonce.
 
+The zero nonce is safe only because `aes_key` is derived from the plaintext, so it is never reused to encrypt two different plaintexts. Reusing a key with the zero nonce across different plaintexts leaks the XOR of those plaintexts and the GHASH authentication subkey, breaking confidentiality and allowing forgery.
+
 ## Decryption
 
 To decrypt:
@@ -46,7 +48,9 @@ To decrypt:
 
 If any step fails, clients MUST reject the blob.
 
-For large or streamable content, encrypt each chunk separately.
+The `blob_hash` and `chk_key` checks are security-critical and MUST NOT be skipped as an optimization.
+
+For large or streamable content, encrypt each chunk separately. Each chunk MUST derive its own `chk_key` from its own plaintext (`chk_key = SHA256(chunk_plaintext)`). Clients MUST NOT reuse one key across multiple chunks with the zero nonce.
 
 ## Blossom URI Parameters
 
@@ -54,18 +58,15 @@ For large or streamable content, encrypt each chunk separately.
 
 - `enc=chk-v1`
 - `k=<chk_key>` as 64 lowercase hex characters
-- `sz=<ciphertext_size>`
 
 If `k` is present, `enc=chk-v1` MUST also be present.
 
 `k` is a bearer secret. Clients MUST NOT send it to Blossom servers.
 
-For `chk-v1`, plaintext size is `sz - 16` when `sz` is present. If `sz < 16`, the URI is invalid.
-
 Example for plaintext `hello`:
 
 ```text
-blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc=chk-v1&k=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824&sz=21
+blossom:70b977414934faa6270f323f117d05dbcc412e9d7ba2354b4d0f88f60aad2461.txt?enc=chk-v1&k=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
 ```
 
 The extension SHOULD describe the plaintext.


### PR DESCRIPTION
## Summary

- Adds BUD-15 for `chk-v1` client-side Content Hash Key (CHK) encrypted Blossom blobs.
- Defines the compact CHK algorithm: `chk_key = SHA256(plaintext)`, HKDF-SHA256, AES-256-GCM with a zero nonce, and blob hash over ciphertext.
- Adds `enc=chk-v1` and `k=<chk_key>` URI parameters.

## Notes

- Servers do not implement this BUD; clients upload ciphertext as normal Blossom blobs.
- Same plaintext produces the same ciphertext and Blossom hash, preserving deduplication, caching, and quota accounting.
- Servers and P2P peers can store ciphertext only, so they do not need to inspect hosted blobs like plaintext media servers.
- Reference implementation: https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree

## Verification

- Ran `git diff --check`.
- Independently reproduced the `hello` vector with Node crypto.
