### PR TITLE
BUD-16: Directory manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ BUDs or **Blossom Upgrade Documents** are short documents that outline an additi
 - [BUD-10: Blossom URI Schema](./buds/10.md)
 - [BUD-11: Nostr Authorization](./buds/11.md)
 - [BUD-12: Blob management endpoints](./buds/12.md)
+- [BUD-16: Directory manifests](./buds/16.md)
 
 ## Endpoints
 

--- a/buds/16.md
+++ b/buds/16.md
@@ -10,13 +10,13 @@ Clients upload directory manifests as normal Blossom blobs. Servers do not need 
 
 ## Encoding Choice
 
-MessagePack is used because it is compact, supports native byte arrays, has mature Rust and TypeScript implementations, and matches the Hashtree reference implementation.
+Directory manifests use MessagePack because it is compact, supports byte arrays directly, and has mature Rust and TypeScript libraries.
 
-Non-normative benchmarks of representative directory manifests found MessagePack to be more than an order of magnitude faster than deterministic CBOR for encoding, with the largest tested directory showing the biggest difference.
+In local benchmarks of representative manifests, MessagePack encoded more than an order of magnitude faster than deterministic CBOR, with the largest tested directory showing the biggest difference.
 
-This BUD defines a deterministic MessagePack profile and test vectors so manifest hashes are reproducible across implementations instead of relying on library defaults.
+This BUD fixes the MessagePack field order, sort order, integer encoding, and test vectors so manifest hashes are reproducible across implementations.
 
-FlatBuffers was also considered. It can be competitive for schema-based reads, but it produced larger payloads in local manifest benchmarks and would require schema tooling or generated bindings for implementers.
+FlatBuffers can be competitive for reads, but was not chosen because it requires schema tooling or generated bindings and produced larger payloads in local manifest benchmarks.
 
 ## Media Type
 

--- a/buds/16.md
+++ b/buds/16.md
@@ -27,6 +27,8 @@ The root object MUST be a MessagePack map with exactly these fields:
 | `l` | array | Directory entries.                                  |
 | `t` | int   | Node type. MUST be `2`.                             |
 
+The root `t` is the node type of the decoded object. This BUD defines node type `2` for directory manifests.
+
 Each link is a map with these fields:
 
 | Key | Type   | Required | Meaning                                                                 |
@@ -37,6 +39,8 @@ Each link is a map with these fields:
 | `n` | string | yes      | Directory entry name.                                                   |
 | `s` | int    | yes      | Plaintext file size, or total descendant file bytes for directories.    |
 | `t` | int    | yes      | Link type: `0` for blob, `1` for file manifest, `2` for directory manifest. |
+
+The link `t` is the type of the linked object. A link type equals the node type of the manifest it points at, except `t = 0`, which points at a raw Blossom blob that has no node type. Thus a `t = 2` link resolves to a `t = 2` directory node, and a `t = 1` link resolves to a BUD-17 `t = 1` file-manifest node.
 
 The `k` field MAY contain a client-side decryption key, such as a BUD-15 CHK key. Clients MUST treat `k` as a bearer secret and MUST NOT send it to Blossom servers.
 

--- a/buds/16.md
+++ b/buds/16.md
@@ -48,9 +48,9 @@ Each link is a map with these fields:
 | `m` | map    | no       | JSON-compatible metadata for the link.                                  |
 | `n` | string | yes      | Directory entry name.                                                   |
 | `s` | int    | yes      | Plaintext file size, or total descendant file bytes for directories.    |
-| `t` | int    | yes      | Link type: `0` for blob, `1` for file manifest, `2` for directory manifest. |
+| `t` | int    | yes      | Link type: `0` for blob, `1` for file manifest, `2` for directory manifest, `3` for directory fanout. |
 
-The link `t` is the type of the linked object. A link type equals the node type of the manifest it points at, except `t = 0`, which points at a raw Blossom blob that has no node type. Thus a `t = 2` link resolves to a `t = 2` directory node, and a `t = 1` link resolves to a BUD-17 `t = 1` file-manifest node.
+The link `t` is the type of the linked object. A link type equals the node type of the manifest it points at, except `t = 0`, which points at a raw Blossom blob that has no node type. Thus a `t = 2` link resolves to a `t = 2` directory node, a `t = 1` link resolves to a BUD-17 `t = 1` file-manifest node, and a `t = 3` link resolves to a BUD-17 `t = 3` directory-fanout node.
 
 The `k` field MAY contain a client-side decryption key, such as a BUD-15 CHK key. Clients MUST treat `k` as a bearer secret and MUST NOT send it to Blossom servers.
 
@@ -58,7 +58,11 @@ For directory links where the total descendant file size is unknown, `s` SHOULD 
 
 The `m` field MUST be a JSON-compatible map with string keys. Clients MUST ignore unknown metadata keys.
 
-Link type `1` is defined by BUD-17.
+The `n` field is required for links in a `t = 2` directory manifest because those links are user-visible directory entries. BUD-17 defines `t = 3` directory fanout nodes whose internal links omit `n`.
+
+Link types `1` and `3` are defined by BUD-17.
+
+Readers MUST return an unsupported type error for unknown link or node types. They MUST NOT reinterpret an unknown type as a blob or another known manifest type.
 
 ## Deterministic Encoding
 
@@ -104,6 +108,7 @@ To resolve a path from a directory manifest, clients SHOULD:
 5. Resolve `t = 2` links as directories.
 6. Resolve `t = 0` links as blobs.
 7. Resolve `t = 1` links as BUD-17 file manifests, or return an unsupported type error.
+8. Resolve `t = 3` links as BUD-17 directory fanout, or return an unsupported type error.
 
 Clients MUST fetch linked objects by `h`. If `k` is present, clients MUST use it only locally.
 

--- a/buds/16.md
+++ b/buds/16.md
@@ -76,7 +76,7 @@ Clients MUST NOT percent-decode an entire path and then split on `/`. If percent
 Example:
 
 ```text
-blossom:16121fa792b3afc72ec8bfc1dc85060518b6adba1429973ecc12891165cbe67e.bdir?sz=61&xs=cdn.example.com
+blossom:16121fa792b3afc72ec8bfc1dc85060518b6adba1429973ecc12891165cbe67e.bdir?xs=cdn.example.com
 ```
 
 ## Resolving a Directory

--- a/buds/16.md
+++ b/buds/16.md
@@ -12,7 +12,7 @@ Clients upload directory manifests as normal Blossom blobs. Servers do not need 
 
 Directory manifests use MessagePack because it is compact, supports byte arrays directly, and has mature Rust and TypeScript libraries.
 
-In local benchmarks of representative manifests, MessagePack encoded more than an order of magnitude faster than deterministic CBOR, with the largest tested directory showing the biggest difference.
+Local benchmarks supported MessagePack as a fast practical choice for this manifest shape, though exact results varied by implementation.
 
 This BUD fixes the MessagePack field order, sort order, integer encoding, and test vectors so manifest hashes are reproducible across implementations.
 

--- a/buds/16.md
+++ b/buds/16.md
@@ -16,6 +16,8 @@ Non-normative benchmarks of representative directory manifests found MessagePack
 
 Deterministic CBOR and canonical JSON/JCS were considered. This BUD defines a deterministic MessagePack profile and test vectors so manifest hashes are reproducible across implementations instead of relying on library defaults.
 
+FlatBuffers was also considered. It can be competitive for schema-based reads, but it produced larger payloads in local manifest benchmarks and would require schema tooling or generated bindings for implementers.
+
 ## Media Type
 
 Directory manifests SHOULD use the following media type when a media type is known:

--- a/buds/16.md
+++ b/buds/16.md
@@ -1,0 +1,170 @@
+# BUD-16
+
+## Directory manifests
+
+`draft` `optional`
+
+This document defines a deterministic directory manifest format for grouping Blossom blobs into named directory trees.
+
+A directory manifest is itself an ordinary Blossom blob. It is uploaded, stored, fetched, mirrored, and deleted using the existing Blossom endpoints. Servers MAY treat directory manifests as opaque bytes and do not need to parse them in order to implement this BUD.
+
+Directory manifests are intended for clients that need to publish a portable tree of files, subdirectories, and higher-level manifests while keeping each referenced object content-addressed by its ordinary Blossom `sha256`.
+
+## Media Type
+
+Directory manifests SHOULD use the following media type when a media type is known:
+
+```text
+application/vnd.blossom.directory+msgpack
+```
+
+Servers that do not recognize this media type MAY use `application/octet-stream`.
+
+Clients SHOULD use the `.bdir` file extension when creating a [BUD-10](./10.md) `blossom:` URI for a directory manifest.
+
+## Manifest Encoding
+
+Directory manifests MUST be encoded as MessagePack maps using the following tree node format.
+
+The root object is a map with exactly these fields:
+
+| Key | Type  | Meaning                                             |
+| --- | ----- | --------------------------------------------------- |
+| `l` | array | Links contained in this node.                       |
+| `t` | int   | Node type. For directory manifests this MUST be `2`. |
+
+Each link is a map with these fields:
+
+| Key | Type   | Required | Meaning                                                                 |
+| --- | ------ | -------- | ----------------------------------------------------------------------- |
+| `h` | bin    | yes      | 32 byte Blossom blob hash of the linked object.                         |
+| `k` | bin    | no       | 32 byte decryption key for the linked object, when needed.              |
+| `m` | map    | no       | JSON-compatible metadata for the link.                                  |
+| `n` | string | yes      | Directory entry name.                                                   |
+| `s` | int    | yes      | Plaintext size in bytes for files, or total descendant file bytes for directories. |
+| `t` | int    | yes      | Link type: `0` for blob, `1` for file manifest, `2` for directory manifest. |
+
+The `k` field is optional and is used when the linked object requires a client-side decryption key, such as a CHK key from BUD-15. Clients MUST treat `k` as a bearer secret and MUST NOT forward it to Blossom servers.
+
+For directory links where the total descendant file size is unknown, `s` SHOULD be `0`.
+
+The `m` metadata field MUST be a JSON-compatible map. Metadata keys MUST be strings. Clients MUST ignore metadata keys they do not understand.
+
+Link type `1` is reserved for chunked file manifests. This BUD defines directory traversal and directory entries, but it does not define the internal format of chunked file manifests.
+
+## Deterministic Encoding
+
+To make manifest bytes and hashes reproducible across implementations:
+
+1. The root map fields MUST be encoded in this order: `l`, `t`.
+2. Link map fields MUST be encoded in this order, omitting absent optional fields: `h`, `k`, `m`, `n`, `s`, `t`.
+3. Links in a directory manifest MUST be sorted by `n` using ascending bytewise order of the UTF-8 encoded names.
+4. Metadata map keys MUST be encoded in ascending bytewise order of the UTF-8 encoded keys.
+5. Integer values MUST use the shortest MessagePack integer encoding that can represent the value.
+6. Binary values MUST use MessagePack binary types, not strings.
+
+The Blossom blob hash for an unencrypted directory manifest is `SHA256(manifest_bytes)`.
+
+If a directory manifest is encrypted before upload, the Blossom blob hash is the hash of the encrypted bytes actually stored on the server. The manifest MUST be decoded only after the client has fetched, verified, and decrypted those bytes.
+
+## Entry Names
+
+Directory entry names:
+
+1. MUST be valid UTF-8 strings.
+2. MUST NOT be empty.
+3. MUST NOT contain `/` or the NUL character.
+4. MUST NOT be `.` or `..`.
+5. MUST be unique within the same directory manifest.
+
+Paths are resolved by splitting the requested path into `/` separated segments, then matching each segment against the `n` field of the current directory's links.
+
+Clients MUST NOT percent-decode an entire path and then split on `/`. If percent-encoded paths are used in a higher-level URI or HTTP route, clients MUST split the path into segments first and decode each segment independently.
+
+## Publishing a Directory
+
+To publish a directory manifest, clients SHOULD:
+
+1. Upload each file blob, subdirectory manifest, or higher-level file manifest referenced by the directory.
+2. Build a directory manifest containing one link for each entry.
+3. Encode the manifest using the deterministic MessagePack rules above.
+4. Upload the manifest bytes using [BUD-02](./02.md#put-upload---upload-blob) `PUT /upload` or another compatible Blossom upload endpoint.
+5. Share the resulting manifest hash using a `blossom:` URI with the `.bdir` extension and any usual BUD-10 discovery hints.
+
+Example:
+
+```text
+blossom:16121fa792b3afc72ec8bfc1dc85060518b6adba1429973ecc12891165cbe67e.bdir?sz=61&xs=cdn.example.com
+```
+
+## Resolving a Directory
+
+To resolve a file path from a directory manifest, clients SHOULD:
+
+1. Fetch the root manifest blob by its Blossom hash.
+2. Verify that the fetched bytes match the requested hash.
+3. Decrypt the manifest first if the root reference includes a decryption key.
+4. Decode the manifest and verify that `t` is `2`.
+5. Look up the next path segment in the directory links by exact `n` match.
+6. If the matching link has `t = 2`, fetch and decode the linked object as another directory manifest.
+7. If the matching link has `t = 0`, fetch the linked object as a blob.
+8. If the matching link has `t = 1`, handle it using a file manifest implementation or return an unsupported type error.
+
+When fetching a linked object, clients MUST request it by the `h` hash. If `k` is present, clients MUST use it only locally for decryption and MUST NOT send it to the server.
+
+## Security Considerations
+
+A public directory manifest reveals entry names, sizes, metadata, linked blob hashes, and any embedded `k` values. Clients that need to hide directory structure or embedded keys SHOULD encrypt the directory manifest itself before upload and share the root decryption key only with authorized readers.
+
+Clients SHOULD bound manifest size, link count, recursion depth, metadata size, and total bytes fetched while resolving directories.
+
+Clients MUST validate names and reject duplicate names before presenting or materializing a directory. This prevents ambiguous path resolution and unsafe filesystem writes.
+
+## Reference Implementation
+
+The Hashtree project includes a reference implementation of this MessagePack tree node format and interoperable test vectors:
+
+```text
+https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree
+```
+
+## Test Vectors
+
+### Empty Directory
+
+```text
+manifest_msgpack: 82a16c90a17402
+manifest_hash: 0218ed9a4fbb0993757f17e5d08d089cb0c6ac851928ba1ba82d337d76c41c0c
+```
+
+Decoded form:
+
+```json
+{
+  "l": [],
+  "t": 2
+}
+```
+
+### Single File Entry
+
+```text
+manifest_msgpack: 82a16c9184a168c420ababababababababababababababababababababababababababababababababa16ea8746573742e747874a17364a17400a17402
+manifest_hash: 16121fa792b3afc72ec8bfc1dc85060518b6adba1429973ecc12891165cbe67e
+```
+
+Decoded form:
+
+```json
+{
+  "l": [
+    {
+      "h": "abababababababababababababababababababababababababababababababab",
+      "n": "test.txt",
+      "s": 100,
+      "t": 0
+    }
+  ],
+  "t": 2
+}
+```

--- a/buds/16.md
+++ b/buds/16.md
@@ -4,11 +4,9 @@
 
 `draft` `optional`
 
-This document defines a deterministic directory manifest format for grouping Blossom blobs into named directory trees.
+This document defines a deterministic MessagePack format for grouping Blossom blobs into named directory trees.
 
-A directory manifest is itself an ordinary Blossom blob. It is uploaded, stored, fetched, mirrored, and deleted using the existing Blossom endpoints. Servers MAY treat directory manifests as opaque bytes and do not need to parse them in order to implement this BUD.
-
-Directory manifests are intended for clients that need to publish a portable tree of files, subdirectories, and higher-level manifests while keeping each referenced object content-addressed by its ordinary Blossom `sha256`.
+Clients upload directory manifests as normal Blossom blobs. Servers do not need to implement this BUD.
 
 ## Media Type
 
@@ -18,43 +16,39 @@ Directory manifests SHOULD use the following media type when a media type is kno
 application/vnd.blossom.directory+msgpack
 ```
 
-Servers that do not recognize this media type MAY use `application/octet-stream`.
-
-Clients SHOULD use the `.bdir` file extension when creating a [BUD-10](./10.md) `blossom:` URI for a directory manifest.
+Clients SHOULD use the `.bdir` file extension in [BUD-10](./10.md) `blossom:` URIs.
 
 ## Manifest Encoding
 
-Directory manifests MUST be encoded as MessagePack maps using the following tree node format.
-
-The root object is a map with exactly these fields:
+The root object MUST be a MessagePack map with exactly these fields:
 
 | Key | Type  | Meaning                                             |
 | --- | ----- | --------------------------------------------------- |
-| `l` | array | Links contained in this node.                       |
-| `t` | int   | Node type. For directory manifests this MUST be `2`. |
+| `l` | array | Directory entries.                                  |
+| `t` | int   | Node type. MUST be `2`.                             |
 
 Each link is a map with these fields:
 
 | Key | Type   | Required | Meaning                                                                 |
 | --- | ------ | -------- | ----------------------------------------------------------------------- |
-| `h` | bin    | yes      | 32 byte Blossom blob hash of the linked object.                         |
-| `k` | bin    | no       | 32 byte decryption key for the linked object, when needed.              |
+| `h` | bin    | yes      | 32 byte Blossom hash of the linked object.                              |
+| `k` | bin    | no       | 32 byte client-side decryption key.                                     |
 | `m` | map    | no       | JSON-compatible metadata for the link.                                  |
 | `n` | string | yes      | Directory entry name.                                                   |
-| `s` | int    | yes      | Plaintext size in bytes for files, or total descendant file bytes for directories. |
+| `s` | int    | yes      | Plaintext file size, or total descendant file bytes for directories.    |
 | `t` | int    | yes      | Link type: `0` for blob, `1` for file manifest, `2` for directory manifest. |
 
-The `k` field is optional and is used when the linked object requires a client-side decryption key, such as a CHK key from BUD-15. Clients MUST treat `k` as a bearer secret and MUST NOT forward it to Blossom servers.
+The `k` field MAY contain a client-side decryption key, such as a BUD-15 CHK key. Clients MUST treat `k` as a bearer secret and MUST NOT send it to Blossom servers.
 
 For directory links where the total descendant file size is unknown, `s` SHOULD be `0`.
 
-The `m` metadata field MUST be a JSON-compatible map. Metadata keys MUST be strings. Clients MUST ignore metadata keys they do not understand.
+The `m` field MUST be a JSON-compatible map with string keys. Clients MUST ignore unknown metadata keys.
 
-Link type `1` is reserved for chunked file manifests. This BUD defines directory traversal and directory entries, but it does not define the internal format of chunked file manifests.
+Link type `1` is defined by BUD-17.
 
 ## Deterministic Encoding
 
-To make manifest bytes and hashes reproducible across implementations:
+To make manifest hashes reproducible:
 
 1. The root map fields MUST be encoded in this order: `l`, `t`.
 2. Link map fields MUST be encoded in this order, omitting absent optional fields: `h`, `k`, `m`, `n`, `s`, `t`.
@@ -62,10 +56,6 @@ To make manifest bytes and hashes reproducible across implementations:
 4. Metadata map keys MUST be encoded in ascending bytewise order of the UTF-8 encoded keys.
 5. Integer values MUST use the shortest MessagePack integer encoding that can represent the value.
 6. Binary values MUST use MessagePack binary types, not strings.
-
-The Blossom blob hash for an unencrypted directory manifest is `SHA256(manifest_bytes)`.
-
-If a directory manifest is encrypted before upload, the Blossom blob hash is the hash of the encrypted bytes actually stored on the server. The manifest MUST be decoded only after the client has fetched, verified, and decrypted those bytes.
 
 ## Entry Names
 
@@ -77,19 +67,11 @@ Directory entry names:
 4. MUST NOT be `.` or `..`.
 5. MUST be unique within the same directory manifest.
 
-Paths are resolved by splitting the requested path into `/` separated segments, then matching each segment against the `n` field of the current directory's links.
+Paths are resolved by splitting on `/` and matching each segment against a link `n`.
 
 Clients MUST NOT percent-decode an entire path and then split on `/`. If percent-encoded paths are used in a higher-level URI or HTTP route, clients MUST split the path into segments first and decode each segment independently.
 
-## Publishing a Directory
-
-To publish a directory manifest, clients SHOULD:
-
-1. Upload each file blob, subdirectory manifest, or higher-level file manifest referenced by the directory.
-2. Build a directory manifest containing one link for each entry.
-3. Encode the manifest using the deterministic MessagePack rules above.
-4. Upload the manifest bytes using [BUD-02](./02.md#put-upload---upload-blob) `PUT /upload` or another compatible Blossom upload endpoint.
-5. Share the resulting manifest hash using a `blossom:` URI with the `.bdir` extension and any usual BUD-10 discovery hints.
+## URI Usage
 
 Example:
 
@@ -99,22 +81,21 @@ blossom:16121fa792b3afc72ec8bfc1dc85060518b6adba1429973ecc12891165cbe67e.bdir?sz
 
 ## Resolving a Directory
 
-To resolve a file path from a directory manifest, clients SHOULD:
+To resolve a path from a directory manifest, clients SHOULD:
 
 1. Fetch the root manifest blob by its Blossom hash.
-2. Verify that the fetched bytes match the requested hash.
-3. Decrypt the manifest first if the root reference includes a decryption key.
-4. Decode the manifest and verify that `t` is `2`.
-5. Look up the next path segment in the directory links by exact `n` match.
-6. If the matching link has `t = 2`, fetch and decode the linked object as another directory manifest.
-7. If the matching link has `t = 0`, fetch the linked object as a blob.
-8. If the matching link has `t = 1`, handle it using a file manifest implementation or return an unsupported type error.
+2. Decrypt it if the root reference has a key.
+3. Decode it and verify `t = 2`.
+4. Look up the next path segment by exact `n` match.
+5. Resolve `t = 2` links as directories.
+6. Resolve `t = 0` links as blobs.
+7. Resolve `t = 1` links as BUD-17 file manifests, or return an unsupported type error.
 
-When fetching a linked object, clients MUST request it by the `h` hash. If `k` is present, clients MUST use it only locally for decryption and MUST NOT send it to the server.
+Clients MUST fetch linked objects by `h`. If `k` is present, clients MUST use it only locally.
 
 ## Security Considerations
 
-A public directory manifest reveals entry names, sizes, metadata, linked blob hashes, and any embedded `k` values. Clients that need to hide directory structure or embedded keys SHOULD encrypt the directory manifest itself before upload and share the root decryption key only with authorized readers.
+A public directory manifest reveals entry names, sizes, metadata, linked blob hashes, and embedded `k` values. Clients that need to hide those values SHOULD encrypt the manifest.
 
 Clients SHOULD bound manifest size, link count, recursion depth, metadata size, and total bytes fetched while resolving directories.
 

--- a/buds/16.md
+++ b/buds/16.md
@@ -8,6 +8,12 @@ This document defines a deterministic MessagePack format for grouping Blossom bl
 
 Clients upload directory manifests as normal Blossom blobs. Servers do not need to implement this BUD.
 
+## Encoding Choice
+
+MessagePack is used because it is compact, supports native byte arrays, has mature Rust and TypeScript implementations, and matches the Hashtree reference implementation.
+
+Deterministic CBOR and canonical JSON/JCS were considered. This BUD defines a deterministic MessagePack profile and test vectors so manifest hashes are reproducible across implementations instead of relying on library defaults.
+
 ## Media Type
 
 Directory manifests SHOULD use the following media type when a media type is known:

--- a/buds/16.md
+++ b/buds/16.md
@@ -12,6 +12,8 @@ Clients upload directory manifests as normal Blossom blobs. Servers do not need 
 
 MessagePack is used because it is compact, supports native byte arrays, has mature Rust and TypeScript implementations, and matches the Hashtree reference implementation.
 
+Non-normative benchmarks of representative directory manifests found MessagePack to be more than an order of magnitude faster than deterministic CBOR for encoding, with the largest tested directory showing the biggest difference.
+
 Deterministic CBOR and canonical JSON/JCS were considered. This BUD defines a deterministic MessagePack profile and test vectors so manifest hashes are reproducible across implementations instead of relying on library defaults.
 
 ## Media Type

--- a/buds/16.md
+++ b/buds/16.md
@@ -14,7 +14,7 @@ MessagePack is used because it is compact, supports native byte arrays, has matu
 
 Non-normative benchmarks of representative directory manifests found MessagePack to be more than an order of magnitude faster than deterministic CBOR for encoding, with the largest tested directory showing the biggest difference.
 
-Deterministic CBOR and canonical JSON/JCS were considered. This BUD defines a deterministic MessagePack profile and test vectors so manifest hashes are reproducible across implementations instead of relying on library defaults.
+This BUD defines a deterministic MessagePack profile and test vectors so manifest hashes are reproducible across implementations instead of relying on library defaults.
 
 FlatBuffers was also considered. It can be competitive for schema-based reads, but it produced larger payloads in local manifest benchmarks and would require schema tooling or generated bindings for implementers.
 


### PR DESCRIPTION
## Summary

- Adds BUD-16 for deterministic MessagePack directory manifests.
- Defines named links with `h`, optional `k`, metadata, sizes, and link types.
- Adds `.bdir` URI guidance, path resolution rules, safety limits, and test vectors.

## Notes

- Servers do not implement this BUD; clients upload manifests as normal Blossom blobs.
- Link type `1` is defined by BUD-17 / PR #106.
- Reference implementation: https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree

## Verification

- Ran `git diff --check`.
- Verified the included MessagePack test vector hashes with Node crypto, including the single-entry manifest size (`sz=61`).