### PR TITLE
BUD-17: Chunked file and directory fanout manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ BUDs or **Blossom Upgrade Documents** are short documents that outline an additi
 - [BUD-10: Blossom URI Schema](./buds/10.md)
 - [BUD-11: Nostr Authorization](./buds/11.md)
 - [BUD-12: Blob management endpoints](./buds/12.md)
+- [BUD-17: Chunked file and directory fanout manifests](./buds/17.md)
 
 ## Endpoints
 

--- a/buds/17.md
+++ b/buds/17.md
@@ -11,7 +11,8 @@ Clients upload file and fanout manifests as normal Blossom blobs. Servers do not
 This BUD uses the MessagePack tree node encoding from BUD-16:
 
 - `t = 1` for file manifests.
-- `t = 2` for directory manifests and directory fanout nodes.
+- `t = 2` for directory manifests.
+- `t = 3` for directory fanout nodes.
 - `l` for an ordered array of links.
 
 ## Constants
@@ -59,21 +60,24 @@ The plaintext file size is the sum of the root manifest link sizes.
 
 ## Directory Fanout
 
-BUD-16 directory manifests contain user-visible named links. Large directories use fanout nodes: `t = 2` manifests whose links are all internal chunks.
+BUD-16 directory manifests (`t = 2`) contain user-visible named links. Large directories use directory fanout nodes (`t = 3`) whose links are unnamed internal children.
 
-Internal chunk links MUST:
+Readers MUST flatten `t = 3` directory fanout nodes when listing or resolving a directory. Internal fanout links MUST NOT be exposed as user-visible entries.
 
-1. Have `t = 2`.
-2. Have names of the form `_chunk_<start>`, where `<start>` is the decimal zero-based index of the first user-visible entry in that subtree.
-3. Point to a directory manifest or fanout node.
+A `t = 2` directory manifest is always listed verbatim. A user-visible directory entry named `_chunk_0` or any other internal-looking name remains a normal entry.
 
-Publishers MUST NOT mix internal chunk links and user-visible entries in the same directory manifest.
+Each link in a `t = 3` fanout node MUST:
 
-Publishers SHOULD NOT create user-visible `t = 2` directory entries named `_chunk_<start>`, because older readers may mistake them for fanout links.
+1. Omit `n`.
+2. Have `t = 2` when it points to a child directory manifest, or `t = 3` when it points to a nested fanout node.
+3. Use `s` for total descendant file bytes, or `0` when unknown.
+4. Include metadata keys `count`, `first`, and `last` in `m`.
 
-Readers MUST flatten directory fanout nodes when listing a directory. A fanout node's internal `_chunk_<start>` links MUST NOT be exposed as user-visible entries.
+`count` is the number of user-visible descendant entries in the child subtree and MUST be a positive integer. `first` and `last` are the first and last user-visible entry names in that subtree after the BUD-16 bytewise name sort.
 
-Readers MUST treat a directory manifest as a fanout node only when every link in that manifest is an internal chunk link. A normal user-visible directory entry named `_chunk_0` remains a normal entry when it appears alongside non-internal entries.
+Fanout links MUST be ordered by subtree order: ascending `first`, non-overlapping bounds, and adjacent subtrees covering the same sorted directory entry sequence that would appear in a flat BUD-16 directory.
+
+Compatibility note: implementations MAY read older draft fanout nodes encoded as `t = 2` directories whose every link is a `t = 2` named `_chunk_<start>` link. New writers MUST use `t = 3`.
 
 ### Splitting Directories
 
@@ -83,11 +87,12 @@ Canonical directory fanout:
 2. If the directory has at most `max_links` entries, publish it as a BUD-16 directory manifest.
 3. Split larger directories into consecutive batches of at most `max_links` entries.
 4. Create one child directory manifest per batch.
-5. Create a parent fanout node with one internal link per child. Link names are `_chunk_0`, `_chunk_174`, and so on when `max_links = 174`.
-6. Internal links use `s` for total descendant file bytes, or `0` when unknown.
-7. Repeat over internal links until the root has at most `max_links` links.
+5. Create a `t = 3` parent fanout node with one unnamed internal link per child.
+6. Each parent link uses `t = 2`, includes `m.count`, `m.first`, and `m.last`, and uses `s` for total descendant file bytes or `0` when unknown.
+7. If a fanout node has more than `max_links` links, group consecutive fanout links into child `t = 3` fanout nodes and create a new `t = 3` parent with links to them.
+8. Repeat until the root fanout node has at most `max_links` links.
 
-Path resolution over a fanout directory requires searching child subtrees for the requested segment. Clients MAY perform a linear scan across child fanout links. Internal chunk links MAY include metadata keys `first` and `last` containing the first and last user-visible entry names in that subtree; when present, clients SHOULD use those bounds to avoid fetching unrelated subtrees.
+Path resolution over a fanout directory uses `first` and `last` to choose the child subtree whose bounds may contain the requested segment. Clients MAY fall back to a linear scan, but MUST verify fetched child manifests by hash before using them.
 
 ## Encrypted Chunks and Manifests
 
@@ -115,7 +120,9 @@ Clients SHOULD bound recursion depth, total manifest count, total link count, to
 
 Clients MUST verify every fetched blob against the hash from its link before using it.
 
-Clients MUST reject file manifests with named links, directory fanout nodes that mix internal and user-visible links, duplicate user-visible names within a directory, or internal chunk names that do not match `_chunk_<start>`.
+Clients MUST reject file manifests with named links, `t = 3` fanout nodes with named links, `t = 3` fanout nodes with links other than `t = 2` or `t = 3`, duplicate user-visible names within a directory, or fanout metadata with missing or invalid `count`, `first`, or `last` bounds.
+
+BUD-16-only readers that encounter `t = 3` MUST return an unsupported type error rather than guessing another type.
 
 ## Reference Implementation
 
@@ -125,7 +132,7 @@ The Hashtree project includes a reference implementation of this tree node forma
 https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree
 ```
 
-## Test Vector
+## Test Vectors
 
 ### Two Chunk File Manifest
 
@@ -158,5 +165,52 @@ Decoded form:
     }
   ],
   "t": 1
+}
+```
+
+### Two Child Directory Fanout
+
+This fanout manifest has two child directory links:
+
+- child 0 hash: `1111111111111111111111111111111111111111111111111111111111111111`
+- child 0 count: `2`
+- child 0 bounds: `a.txt` through `b.txt`
+- child 0 size: `30`
+- child 1 hash: `2222222222222222222222222222222222222222222222222222222222222222`
+- child 1 count: `1`
+- child 1 bounds: `c.txt` through `c.txt`
+- child 1 size: `40`
+
+```text
+manifest_msgpack: 82a16c9284a168c4201111111111111111111111111111111111111111111111111111111111111111a16d83a5636f756e7402a56669727374a5612e747874a46c617374a5622e747874a1731ea1740284a168c4202222222222222222222222222222222222222222222222222222222222222222a16d83a5636f756e7401a56669727374a5632e747874a46c617374a5632e747874a17328a17402a17403
+manifest_hash: 6626ab03b5468f417d888fa25fa22b48f5bcb7dfafb88eef34c638d167afc0a3
+```
+
+Decoded form:
+```json
+{
+  "l": [
+    {
+      "h": "1111111111111111111111111111111111111111111111111111111111111111",
+      "m": {
+        "count": 2,
+        "first": "a.txt",
+        "last": "b.txt"
+      },
+      "s": 30,
+      "t": 2
+    },
+    {
+      "h": "2222222222222222222222222222222222222222222222222222222222222222",
+      "m": {
+        "count": 1,
+        "first": "c.txt",
+        "last": "c.txt"
+      },
+      "s": 40,
+      "t": 2
+    }
+  ],
+  "t": 3
 }
 ```

--- a/buds/17.md
+++ b/buds/17.md
@@ -102,7 +102,7 @@ Clients SHOULD use the `.bfile` extension for file manifests and `.bdir` for dir
 Examples:
 
 ```text
-blossom:559b726c38295aa0ecbbaef43d438cc86dd63324a0c3e9426dc5f1d0285f483f.bfile?sz=93&xs=cdn.example.com
+blossom:559b726c38295aa0ecbbaef43d438cc86dd63324a0c3e9426dc5f1d0285f483f.bfile?xs=cdn.example.com
 ```
 
 ```text

--- a/buds/17.md
+++ b/buds/17.md
@@ -4,9 +4,9 @@
 
 `draft` `optional`
 
-This document defines a deterministic way to split large files and large directories into multiple Blossom blobs.
+This document defines deterministic manifests for large files and large directories.
 
-Chunked files and directory fanout nodes are ordinary Blossom blobs. Servers MAY treat them as opaque bytes and do not need to parse this format.
+Clients upload file and fanout manifests as normal Blossom blobs. Servers do not need to implement this BUD.
 
 This BUD uses the MessagePack tree node encoding from BUD-16:
 
@@ -16,27 +16,27 @@ This BUD uses the MessagePack tree node encoding from BUD-16:
 
 ## Constants
 
-Implementations that want canonical BUD-17 roots SHOULD use:
+Canonical BUD-17 roots use:
 
 | Name              | Value       | Meaning                                      |
 | ----------------- | ----------- | -------------------------------------------- |
 | `chunk_size`      | `2097152`   | Maximum plaintext bytes in each leaf chunk.  |
 | `max_links`       | `174`       | Maximum links in a file or directory node.   |
 
-Implementations MAY use different values for local policy reasons, but doing so changes the resulting manifest bytes and root hashes.
+Different values produce different manifest bytes and root hashes.
 
 ## File Manifests
 
 A file manifest is a MessagePack tree node with `t = 1`.
 
-File manifest links MUST be ordered by ascending byte offset. File manifest links MUST NOT include an `n` name field.
+File manifest links MUST be ordered by ascending byte offset and MUST NOT include `n`.
 
 Each link in a file manifest has these fields:
 
 | Key | Type | Required | Meaning                                                            |
 | --- | ---- | -------- | ------------------------------------------------------------------ |
-| `h` | bin  | yes      | 32 byte Blossom blob hash of the linked object.                    |
-| `k` | bin  | no       | 32 byte decryption key for the linked object, when needed.         |
+| `h` | bin  | yes      | 32 byte Blossom hash of the linked object.                         |
+| `k` | bin  | no       | 32 byte client-side decryption key.                                |
 | `s` | int  | yes      | Plaintext byte length represented by this link.                    |
 | `t` | int  | yes      | Link type: `0` for a leaf chunk, `1` for another file manifest.    |
 
@@ -44,33 +44,32 @@ File manifest links MAY include an `m` metadata map, but clients MUST NOT requir
 
 ### Splitting Files
 
-To publish a file using canonical BUD-17 chunking:
+Canonical file chunking:
 
-1. If the file is at most `chunk_size` bytes, clients MAY publish it as a single ordinary Blossom blob without a file manifest.
+1. If the file is at most `chunk_size` bytes, clients MAY publish it as a single blob without a file manifest.
 2. Split larger files into consecutive chunks of at most `chunk_size` bytes.
-3. Upload each leaf chunk as an ordinary Blossom blob.
-4. Create a link for each leaf chunk with `t = 0`, `s` set to the plaintext chunk size, and `k` set when the chunk is encrypted.
-5. If the link array has more than `max_links` entries, split it into consecutive batches of at most `max_links` links. For each batch, create and upload a child file manifest with `t = 1`, then replace the batch with a parent link using `t = 1` and `s` equal to the sum of the batch's plaintext sizes.
-6. Repeat until the root file manifest has at most `max_links` links.
-7. Upload the root file manifest and share its Blossom hash.
+3. Create a `t = 0` link for each chunk with `h`, `s`, and optional `k`.
+4. If a node has more than `max_links` links, group consecutive links into child `t = 1` manifests of at most `max_links` links.
+5. Parent links to child manifests use `t = 1` and `s` equal to the sum of descendant plaintext sizes.
+6. Repeat until the root has at most `max_links` links.
 
-Readers MUST recursively traverse `t = 1` links and concatenate `t = 0` leaf chunks in manifest order.
+Readers MUST recursively traverse `t = 1` links and concatenate `t = 0` chunks in manifest order.
 
 The plaintext file size is the sum of the root manifest link sizes.
 
 ## Directory Fanout
 
-BUD-16 directory manifests contain user-visible links with names. For large directories, BUD-17 defines an internal fanout layer made of additional `t = 2` directory manifests.
+BUD-16 directory manifests contain user-visible named links. Large directories use fanout nodes: `t = 2` manifests whose links are all internal chunks.
 
-A directory fanout node is a non-empty directory manifest whose links are all internal chunk links. Internal chunk links MUST:
+Internal chunk links MUST:
 
 1. Have `t = 2`.
-2. Have names of the form `_chunk_<start>`, where `<start>` is the decimal zero-based index of the first user-visible entry contained in that subtree.
-3. Point to another directory manifest or directory fanout node.
+2. Have names of the form `_chunk_<start>`, where `<start>` is the decimal zero-based index of the first user-visible entry in that subtree.
+3. Point to a directory manifest or fanout node.
 
 Publishers MUST NOT mix internal chunk links and user-visible entries in the same directory manifest.
 
-Publishers SHOULD NOT create user-visible directory entries whose name matches `_chunk_<start>` and whose link type is `2`, because older readers may mistake them for internal fanout links.
+Publishers SHOULD NOT create user-visible `t = 2` directory entries named `_chunk_<start>`, because older readers may mistake them for fanout links.
 
 Readers MUST flatten directory fanout nodes when listing a directory. A fanout node's internal `_chunk_<start>` links MUST NOT be exposed as user-visible entries.
 
@@ -78,23 +77,23 @@ Readers MUST treat a directory manifest as a fanout node only when every link in
 
 ### Splitting Directories
 
-To publish a directory using canonical BUD-17 fanout:
+Canonical directory fanout:
 
 1. Sort all user-visible entries by ascending bytewise order of their UTF-8 encoded names.
 2. If the directory has at most `max_links` entries, publish it as a BUD-16 directory manifest.
 3. Split larger directories into consecutive batches of at most `max_links` entries.
-4. For each batch, create and upload a child directory manifest containing the user-visible entries in that batch.
-5. Create a parent directory manifest containing one internal chunk link for each child. The first child link is named `_chunk_0`, the second `_chunk_174`, and so on when `max_links = 174`.
-6. If the parent has more than `max_links` links, repeat the same fanout process over the internal chunk links.
-7. Upload the root directory fanout node and share its Blossom hash.
+4. Create one child directory manifest per batch.
+5. Create a parent fanout node with one internal link per child. Link names are `_chunk_0`, `_chunk_174`, and so on when `max_links = 174`.
+6. Internal links use `s` for total descendant file bytes, or `0` when unknown.
+7. Repeat over internal links until the root has at most `max_links` links.
 
 Path resolution over a fanout directory requires searching child subtrees for the requested segment. Clients MAY perform a linear scan across child fanout links. Internal chunk links MAY include metadata keys `first` and `last` containing the first and last user-visible entry names in that subtree; when present, clients SHOULD use those bounds to avoid fetching unrelated subtrees.
 
 ## Encrypted Chunks and Manifests
 
-When a linked object is encrypted, the link's `k` field carries the decryption key needed by authorized readers.
+When a linked object is encrypted, `k` carries the decryption key.
 
-If a parent manifest is public and a child link contains `k`, that key is public to anyone who can read the parent manifest. Clients that need to hide chunk keys, file structure, or directory names SHOULD encrypt the parent manifest itself and share the root key only with authorized readers.
+A public parent manifest reveals child keys, file structure, and directory names. Clients that need to hide those values SHOULD encrypt the parent manifest.
 
 ## Blossom URI Usage
 

--- a/buds/17.md
+++ b/buds/17.md
@@ -1,0 +1,163 @@
+# BUD-17
+
+## Chunked file and directory fanout manifests
+
+`draft` `optional`
+
+This document defines a deterministic way to split large files and large directories into multiple Blossom blobs.
+
+Chunked files and directory fanout nodes are ordinary Blossom blobs. Servers MAY treat them as opaque bytes and do not need to parse this format.
+
+This BUD uses the MessagePack tree node encoding from BUD-16:
+
+- `t = 1` for file manifests.
+- `t = 2` for directory manifests and directory fanout nodes.
+- `l` for an ordered array of links.
+
+## Constants
+
+Implementations that want canonical BUD-17 roots SHOULD use:
+
+| Name              | Value       | Meaning                                      |
+| ----------------- | ----------- | -------------------------------------------- |
+| `chunk_size`      | `2097152`   | Maximum plaintext bytes in each leaf chunk.  |
+| `max_links`       | `174`       | Maximum links in a file or directory node.   |
+
+Implementations MAY use different values for local policy reasons, but doing so changes the resulting manifest bytes and root hashes.
+
+## File Manifests
+
+A file manifest is a MessagePack tree node with `t = 1`.
+
+File manifest links MUST be ordered by ascending byte offset. File manifest links MUST NOT include an `n` name field.
+
+Each link in a file manifest has these fields:
+
+| Key | Type | Required | Meaning                                                            |
+| --- | ---- | -------- | ------------------------------------------------------------------ |
+| `h` | bin  | yes      | 32 byte Blossom blob hash of the linked object.                    |
+| `k` | bin  | no       | 32 byte decryption key for the linked object, when needed.         |
+| `s` | int  | yes      | Plaintext byte length represented by this link.                    |
+| `t` | int  | yes      | Link type: `0` for a leaf chunk, `1` for another file manifest.    |
+
+File manifest links MAY include an `m` metadata map, but clients MUST NOT require metadata to reassemble a file.
+
+### Splitting Files
+
+To publish a file using canonical BUD-17 chunking:
+
+1. If the file is at most `chunk_size` bytes, clients MAY publish it as a single ordinary Blossom blob without a file manifest.
+2. Split larger files into consecutive chunks of at most `chunk_size` bytes.
+3. Upload each leaf chunk as an ordinary Blossom blob.
+4. Create a link for each leaf chunk with `t = 0`, `s` set to the plaintext chunk size, and `k` set when the chunk is encrypted.
+5. If the link array has more than `max_links` entries, split it into consecutive batches of at most `max_links` links. For each batch, create and upload a child file manifest with `t = 1`, then replace the batch with a parent link using `t = 1` and `s` equal to the sum of the batch's plaintext sizes.
+6. Repeat until the root file manifest has at most `max_links` links.
+7. Upload the root file manifest and share its Blossom hash.
+
+Readers MUST recursively traverse `t = 1` links and concatenate `t = 0` leaf chunks in manifest order.
+
+The plaintext file size is the sum of the root manifest link sizes.
+
+## Directory Fanout
+
+BUD-16 directory manifests contain user-visible links with names. For large directories, BUD-17 defines an internal fanout layer made of additional `t = 2` directory manifests.
+
+A directory fanout node is a non-empty directory manifest whose links are all internal chunk links. Internal chunk links MUST:
+
+1. Have `t = 2`.
+2. Have names of the form `_chunk_<start>`, where `<start>` is the decimal zero-based index of the first user-visible entry contained in that subtree.
+3. Point to another directory manifest or directory fanout node.
+
+Publishers MUST NOT mix internal chunk links and user-visible entries in the same directory manifest.
+
+Publishers SHOULD NOT create user-visible directory entries whose name matches `_chunk_<start>` and whose link type is `2`, because older readers may mistake them for internal fanout links.
+
+Readers MUST flatten directory fanout nodes when listing a directory. A fanout node's internal `_chunk_<start>` links MUST NOT be exposed as user-visible entries.
+
+Readers MUST treat a directory manifest as a fanout node only when every link in that manifest is an internal chunk link. A normal user-visible directory entry named `_chunk_0` remains a normal entry when it appears alongside non-internal entries.
+
+### Splitting Directories
+
+To publish a directory using canonical BUD-17 fanout:
+
+1. Sort all user-visible entries by ascending bytewise order of their UTF-8 encoded names.
+2. If the directory has at most `max_links` entries, publish it as a BUD-16 directory manifest.
+3. Split larger directories into consecutive batches of at most `max_links` entries.
+4. For each batch, create and upload a child directory manifest containing the user-visible entries in that batch.
+5. Create a parent directory manifest containing one internal chunk link for each child. The first child link is named `_chunk_0`, the second `_chunk_174`, and so on when `max_links = 174`.
+6. If the parent has more than `max_links` links, repeat the same fanout process over the internal chunk links.
+7. Upload the root directory fanout node and share its Blossom hash.
+
+Path resolution over a fanout directory requires searching child subtrees for the requested segment. Clients MAY perform a linear scan across child fanout links. Internal chunk links MAY include metadata keys `first` and `last` containing the first and last user-visible entry names in that subtree; when present, clients SHOULD use those bounds to avoid fetching unrelated subtrees.
+
+## Encrypted Chunks and Manifests
+
+When a linked object is encrypted, the link's `k` field carries the decryption key needed by authorized readers.
+
+If a parent manifest is public and a child link contains `k`, that key is public to anyone who can read the parent manifest. Clients that need to hide chunk keys, file structure, or directory names SHOULD encrypt the parent manifest itself and share the root key only with authorized readers.
+
+## Blossom URI Usage
+
+Clients SHOULD use the `.bfile` extension for file manifests and `.bdir` for directory manifests or directory fanout roots.
+
+Examples:
+
+```text
+blossom:559b726c38295aa0ecbbaef43d438cc86dd63324a0c3e9426dc5f1d0285f483f.bfile?sz=93&xs=cdn.example.com
+```
+
+```text
+blossom:<directory-fanout-root-hash>.bdir?xs=cdn.example.com
+```
+
+## Security Considerations
+
+Clients SHOULD bound recursion depth, total manifest count, total link count, total plaintext size, and total bytes fetched.
+
+Clients MUST verify every fetched blob against the hash from its link before using it.
+
+Clients MUST reject file manifests with named links, directory fanout nodes that mix internal and user-visible links, duplicate user-visible names within a directory, or internal chunk names that do not match `_chunk_<start>`.
+
+## Reference Implementation
+
+The Hashtree project includes a reference implementation of this tree node format and interoperable test vectors:
+
+```text
+https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree
+```
+
+## Test Vector
+
+### Two Chunk File Manifest
+
+This file manifest has two leaf chunks:
+
+- chunk 0 hash: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+- chunk 0 size: `100`
+- chunk 1 hash: `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`
+- chunk 1 size: `50`
+
+```text
+manifest_msgpack: 82a16c9283a168c420aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa17364a1740083a168c420bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbba17332a17400a17401
+manifest_hash: 559b726c38295aa0ecbbaef43d438cc86dd63324a0c3e9426dc5f1d0285f483f
+```
+
+Decoded form:
+
+```json
+{
+  "l": [
+    {
+      "h": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "s": 100,
+      "t": 0
+    },
+    {
+      "h": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "s": 50,
+      "t": 0
+    }
+  ],
+  "t": 1
+}
+```


### PR DESCRIPTION
## Summary

- Adds BUD-17 for chunked file manifests (`t = 1`) and directory fanout nodes (`t = 2`).
- Defines canonical chunking constants: 2 MiB chunks and max 174 links per node.
- Specifies recursive file traversal, directory `_chunk_<start>` fanout, encrypted child keys, URI extensions, safety limits, and test vectors.

## Notes

- Depends conceptually on BUD-16 / PR #105 for the shared MessagePack tree node encoding.
- Servers do not implement this BUD; clients upload file and fanout manifests as normal Blossom blobs.
- Reference implementation: https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree

## Verification

- Ran `git diff --check`.
- Verified the two-chunk file manifest vector with Node crypto: size 93 bytes, hash `559b726c38295aa0ecbbaef43d438cc86dd63324a0c3e9426dc5f1d0285f483f`.