### PR TITLE
BUD-18: Hashtree references

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ BUDs or **Blossom Upgrade Documents** are short documents that outline an additi
 - [BUD-10: Blossom URI Schema](./buds/10.md)
 - [BUD-11: Nostr Authorization](./buds/11.md)
 - [BUD-12: Blob management endpoints](./buds/12.md)
+- [BUD-18: Hashtree references](./buds/18.md)
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Blossom Servers expose a few endpoints for managing blobs
 | ------- | ------------------- | ------------------ |
 | `24242` | Authorization token | [11](./buds/11.md) |
 | `10063` | User Server List    | [03](./buds/03.md) |
+| `30064` | Hashtree Root       | [18](./buds/18.md) |
 
 ## License
 

--- a/buds/18.md
+++ b/buds/18.md
@@ -1,0 +1,131 @@
+# BUD-18
+
+## Hashtree references
+
+`draft` `optional`
+
+This document defines `htree` references for files and directories inside Hashtree manifests stored as Blossom blobs.
+
+Clients and gateways resolve `htree` references. Blossom servers only store the referenced blobs.
+
+This BUD depends on BUD-15, BUD-16, and BUD-17.
+
+## Rationale
+
+`blossom:` URIs address one immutable blob.
+
+Hashtree references address a path inside a tree. The root can be mutable, using an owner's `npub` and tree name, or immutable, using an `nhash`.
+
+Mutable references are useful for websites, repositories, catalogs, backups, and app data where the current root changes. Immutable references are useful for snapshots and permalinks.
+
+## Reference Forms
+
+Clients SHOULD use:
+
+```text
+htree://<npub>/<tree-name>[/<path>]
+htree://<nhash>[/<path>]
+```
+
+Gateways MAY expose equivalent HTTP paths:
+
+```text
+/htree/<npub>/<tree-name>[/<path>]
+/htree/<nhash>[/<path>]
+```
+
+Examples:
+
+```text
+htree://npub1example/photos/2026/summer.jpg
+htree://npub1example/releases%2Fnostr-vpn/v0.3.0/app.zip
+htree://nhash1example/docs/index.html
+```
+
+The `npub` form is mutable. The first segment after `npub` is the tree name. The remaining segments are the path inside that tree.
+
+The `nhash` form is immutable. The `nhash` selects the root manifest. All remaining segments are the path inside that root.
+
+This BUD does not define a bech32 form for mutable references.
+
+## Path Encoding
+
+Each path segment MUST be percent-encoded independently.
+
+Clients MUST split paths into segments before percent-decoding. They MUST NOT percent-decode an entire path and then split on `/`.
+
+A tree name is one logical segment. If the tree name contains `/`, that slash MUST be percent-encoded.
+
+## Mutable Root Resolution
+
+The mutable form resolves through a Nostr kind `30078` parameterized replaceable event:
+
+- event author: NIP-19 pubkey decoded from `npub`
+- `d` tag: tree name
+- `hash` tag: 32 byte root manifest hash as 64 lowercase hex characters
+- optional `key` tag: 32 byte root decryption key as 64 lowercase hex characters
+- optional `l` tag: `hashtree`
+
+Clients SHOULD use the latest valid event for the author and `d` tag according to Nostr replaceable event rules. If multiple valid events have the same `created_at`, clients SHOULD use the one with the lexicographically greatest event id.
+
+The root hash MUST identify a BUD-16 directory manifest or BUD-17 file manifest.
+
+## Immutable Root Encoding
+
+`nhash` is a bech32 identifier with human-readable part `nhash`.
+
+The payload is TLV encoded:
+
+| Type | Meaning                         | Required |
+| ---- | ------------------------------- | -------- |
+| `0`  | 32 byte root manifest hash      | yes      |
+| `5`  | 32 byte root client-side key    | no       |
+
+TLV records are encoded as:
+
+```text
+type: 1 byte
+length: 1 byte
+value: length bytes
+```
+
+For compatibility, clients MAY decode legacy `nhash` values whose bech32 payload is exactly 32 bytes as the root manifest hash with no key.
+
+## Tree Resolution
+
+To resolve an `htree` reference:
+
+1. Resolve the root from `npub` or `nhash`.
+2. Fetch the root manifest.
+3. Decrypt it locally using BUD-15 if the root has a key.
+4. Decode the root manifest.
+5. Traverse the path using BUD-16 directory rules and BUD-17 file manifest rules.
+6. If a needed child object has a key, decrypt it locally using BUD-15.
+
+An empty path resolves to the root object.
+
+Clients MUST reject invalid `npub`, invalid `nhash`, invalid percent encoding, missing mutable roots, duplicate directory names, unsupported link types, and hash or decryption failures.
+
+## Security
+
+Mutable references can change when the owner publishes a new root event. Clients that need a stable historical reference SHOULD use the `nhash` form.
+
+An `nhash` that includes a key is a bearer secret.
+
+Clients SHOULD bound manifest size, recursion depth, and total bytes fetched.
+
+## Reference Implementation
+
+```text
+https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree
+```
+
+## Test Vector
+
+### `nhash` Without Key
+
+```text
+root_hash: abababababababababababababababababababababababababababababababab
+payload: 0020abababababababababababababababababababababababababababababababab
+nhash: nhash1qqs2h2at4w46h2at4w46h2at4w46h2at4w46h2at4w46h2at4w46h2cym3cqn
+```

--- a/buds/18.md
+++ b/buds/18.md
@@ -60,12 +60,14 @@ A tree name is one logical segment. If the tree name contains `/`, that slash MU
 
 ## Mutable Root Resolution
 
-The mutable form resolves through a Nostr kind `30078` parameterized replaceable event:
+The mutable form resolves through a Nostr kind `30064` parameterized replaceable event:
 
 - event author: NIP-19 pubkey decoded from `npub`
 - `d` tag: tree name
 - `hash` tag: 32 byte root manifest hash as 64 lowercase hex characters
 - optional `l` tag: `hashtree`
+
+Clients SHOULD publish new mutable roots as kind `30064`. For compatibility with older implementations, clients MAY also read kind `30078` events that otherwise match this section.
 
 Clients SHOULD use the latest valid event for the author and `d` tag according to Nostr replaceable event rules. If multiple valid events have the same `created_at`, clients SHOULD use the one with the lexicographically greatest event id.
 
@@ -94,10 +96,10 @@ Link-private roots MAY also publish `selfEncryptedKey` or `selfEncryptedLinkKey`
 
 The payload is TLV encoded:
 
-| Type | Meaning                         | Required |
-| ---- | ------------------------------- | -------- |
-| `0`  | 32 byte root manifest hash      | yes      |
-| `5`  | 32 byte root client-side key    | no       |
+| Type | Meaning                      | Namespace                        | Required |
+| ---- | ---------------------------- | -------------------------------- | -------- |
+| `0`  | 32 byte root manifest hash   | NIP-19 `special` primary value   | yes      |
+| `5`  | 32 byte root client-side key | BUD-18 local `nhash` assignment  | no       |
 
 TLV records are encoded as:
 
@@ -107,7 +109,11 @@ length: 1 byte
 value: length bytes
 ```
 
-For compatibility, clients MAY decode legacy `nhash` values whose bech32 payload is exactly 32 bytes as the root manifest hash with no key.
+Other TLV types are reserved for future BUD-18 `nhash` extensions. Types `1`, `2`, and `3` do not carry NIP-19 relay, author, or kind semantics in `nhash` unless a future revision explicitly defines them.
+
+Type `5` is intentionally local to `nhash` so the optional root key is not confused with NIP-19 relay, author, or kind fields.
+
+For compatibility, clients MAY decode legacy `nhash` values whose bech32 payload is exactly 32 bytes as the root manifest hash with no key. Any other payload length MUST be decoded as TLV.
 
 ## Tree Resolution
 

--- a/buds/18.md
+++ b/buds/18.md
@@ -2,7 +2,7 @@
 
 ## Hashtree references
 
-`draft` `optional`
+`optional`
 
 This document defines `htree` references for files and directories inside Hashtree manifests stored as Blossom blobs.
 
@@ -50,6 +50,8 @@ This BUD does not define a bech32 form for mutable references.
 
 ## Path Encoding
 
+Query strings and fragments are not part of the tree path.
+
 Each path segment MUST be percent-encoded independently.
 
 Clients MUST split paths into segments before percent-decoding. They MUST NOT percent-decode an entire path and then split on `/`.
@@ -63,12 +65,28 @@ The mutable form resolves through a Nostr kind `30078` parameterized replaceable
 - event author: NIP-19 pubkey decoded from `npub`
 - `d` tag: tree name
 - `hash` tag: 32 byte root manifest hash as 64 lowercase hex characters
-- optional `key` tag: 32 byte root decryption key as 64 lowercase hex characters
 - optional `l` tag: `hashtree`
 
 Clients SHOULD use the latest valid event for the author and `d` tag according to Nostr replaceable event rules. If multiple valid events have the same `created_at`, clients SHOULD use the one with the lexicographically greatest event id.
 
 The root hash MUST identify a BUD-16 directory manifest or BUD-17 file manifest.
+
+## Visibility
+
+Mutable root events define three visibility scopes.
+
+Public roots either need no key, or publish the root key in a `key` tag as 64 lowercase hex characters. Anyone who can read the event can resolve the root.
+
+Link-private roots publish:
+
+- `encryptedKey`: `root_key XOR link_key`, as 64 lowercase hex characters
+- `keyId`: first 8 bytes of `SHA256(link_key)`, as 16 lowercase hex characters
+
+The `link_key` is 32 random bytes. Link-private `htree` references MAY include it as `k=<link_key>` in the query string. Clients compute `root_key = encryptedKey XOR link_key` and SHOULD verify `keyId` when present.
+
+Owner-private roots publish `selfEncryptedKey`, encrypted to the event author using NIP-44. Only the owner can recover the root key.
+
+Link-private roots MAY also publish `selfEncryptedKey` or `selfEncryptedLinkKey` so the owner can recover access without the shared link.
 
 ## Immutable Root Encoding
 
@@ -110,7 +128,9 @@ Clients MUST reject invalid `npub`, invalid `nhash`, invalid percent encoding, m
 
 Mutable references can change when the owner publishes a new root event. Clients that need a stable historical reference SHOULD use the `nhash` form.
 
-An `nhash` that includes a key is a bearer secret.
+An `nhash` that includes a key is a bearer secret. An `htree` reference with `k` is also a bearer secret.
+
+Clients MUST NOT send `k` values to Blossom servers.
 
 Clients SHOULD bound manifest size, recursion depth, and total bytes fetched.
 


### PR DESCRIPTION
## Summary

- Adds BUD-18 for `htree` references to files and directories inside Hashtree manifests stored as Blossom blobs.
- Defines mutable `htree://<npub>/<tree-name>/<path>` references and immutable `htree://<nhash>/<path>` references.
- Defines public, link-private, and owner-private mutable root visibility scopes.
- Defines `nhash` bech32 TLV encoding and an `nhash` test vector.

## Notes

- Depends on BUD-15 / PR #104, BUD-16 / PR #105, and BUD-17 / PR #106.
- Leaves `npath` out; mutable references use the readable `npub/tree/path` form.
- Keeps resolution in clients and gateways. Blossom servers only store the referenced blobs.
- Reference implementation: https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/hashtree

## Verification

- Ran `git diff --check`.
- Computed the `nhash` bech32 test vector from the TLV payload with an inline encoder.