### PR TITLE
BUD-00: allow BUDs to define client-side conventions

### DIFF
--- a/buds/00.md
+++ b/buds/00.md
@@ -12,7 +12,9 @@ All occurences of "MUST", "MUST NOT", "SHOULD", "SHOULD NOT" MUST be interpreted
 
 ## BUDs
 
-BUDs or "Blossom Upgrade Documents" are short documents that outline an additional requirement or feature that a blossom server MUST or MAY implement.
+BUDs or "Blossom Upgrade Documents" are short documents that outline an additional feature of the Blossom protocol.
+
+A BUD MAY define a requirement or feature that a blossom server MUST or MAY implement, or a client-side convention or data format built on top of Blossom blobs that servers do not need to implement (for example the `blossom:` URI schema in [BUD-10](./10.md)).
 
 ## Blobs
 


### PR DESCRIPTION
The definition restricted BUDs to features a server implements, but BUD-10 (the blossom: URI schema) is already a client-side convention. Broaden the definition to cover client-side conventions and data formats built on Blossom blobs that servers do not implement.