### PR TITLE
BUD-02: Recommend server-side MIME type detection from magic bytes

### DIFF
--- a/buds/02.md
+++ b/buds/02.md
@@ -43,6 +43,18 @@ The server MUST NOT modify the blob in any way and MUST compute the sha256 hash 
 
 Clients SHOULD include `Content-Type` and `Content-Length` headers specifying the MIME type and size of the data. Clients MAY provide an `X-SHA-256` header containing the lowercase hex-encoded sha256 of the request body. A server MAY use this value to enforce rejection policies or perform authorization checks prior to persisting the blob.
 
+### MIME type detection (Recommended)
+
+When a client uploads a blob with `Content-Type: application/octet-stream` (or omits the header entirely), servers SHOULD detect the MIME type by inspecting the blob's magic bytes (file signature). This ensures that the `type` field in the [Blob Descriptor](#blob-descriptor) and the file extension in the `url` field are correct even when the client does not know or correctly identify the blob's type.
+
+If the client sends a specific `Content-Type` other than `application/octet-stream`, servers SHOULD trust the client-provided value and skip detection.
+
+Servers that implement detection SHOULD use a well-maintained magic-bytes library (e.g. [`file-type`](https://github.com/sindresorhus/file-type) for Node.js, [`python-magic`](https://github.com/ahupp/python-magic) for Python). Detection only needs to examine the first few hundred bytes of the blob.
+
+If detection fails to identify a known type, the server MUST fall back to `application/octet-stream`.
+
+This recommendation addresses the common case where automated clients (AI agents, CI pipelines, CLI tools) upload files without knowing the MIME type, causing the server to store and serve them with a generic type. This leads to browsers saving files with `.bin` extensions and media failing to render inline in Nostr clients.
+
 If the blob was newly stored, the endpoint MUST respond with `201 Created` and a [Blob Descriptor](#blob-descriptor) in the response body.
 If the blob already exists, the endpoint MUST respond with `200 OK` and a [Blob Descriptor](#blob-descriptor) in the response body.
 

--- a/buds/02.md
+++ b/buds/02.md
@@ -43,17 +43,17 @@ The server MUST NOT modify the blob in any way and MUST compute the sha256 hash 
 
 Clients SHOULD include `Content-Type` and `Content-Length` headers specifying the MIME type and size of the data. Clients MAY provide an `X-SHA-256` header containing the lowercase hex-encoded sha256 of the request body. A server MAY use this value to enforce rejection policies or perform authorization checks prior to persisting the blob.
 
-### MIME type detection (Recommended)
+### MIME type detection (Optional)
 
-When a client uploads a blob with `Content-Type: application/octet-stream` (or omits the header entirely), servers SHOULD detect the MIME type by inspecting the blob's magic bytes (file signature). This ensures that the `type` field in the [Blob Descriptor](#blob-descriptor) and the file extension in the `url` field are correct even when the client does not know or correctly identify the blob's type.
+When a client uploads a blob with `Content-Type: application/octet-stream` (or omits the header entirely), servers MAY detect the MIME type by inspecting the blob's magic bytes (file signature). This improves UX by ensuring the `type` field in the [Blob Descriptor](#blob-descriptor) and the file extension in the `url` field are correct even when the client does not know or correctly identify the blob's type.
 
-If the client sends a specific `Content-Type` other than `application/octet-stream`, servers SHOULD trust the client-provided value and skip detection.
+If the client sends a specific `Content-Type` other than `application/octet-stream`, servers MAY trust the client-provided value and skip detection.
 
-Servers that implement detection SHOULD use a well-maintained magic-bytes library (e.g. [`file-type`](https://github.com/sindresorhus/file-type) for Node.js, [`python-magic`](https://github.com/ahupp/python-magic) for Python). Detection only needs to examine the first few hundred bytes of the blob.
+Servers that implement detection MAY use a well-maintained magic-bytes library (e.g. [`file-type`](https://github.com/sindresorhus/file-type) for Node.js, [`python-magic`](https://github.com/ahupp/python-magic) for Python). Detection only needs to examine the first few hundred bytes of the blob.
 
-If detection fails to identify a known type, the server MUST fall back to `application/octet-stream`.
+If detection fails to identify a known type, the server MAY fall back to `application/octet-stream`.
 
-This recommendation addresses the common case where automated clients (AI agents, CI pipelines, CLI tools) upload files without knowing the MIME type, causing the server to store and serve them with a generic type. This leads to browsers saving files with `.bin` extensions and media failing to render inline in Nostr clients.
+This is a UX feature that addresses the common case where automated clients (AI agents, CI pipelines, CLI tools) upload files without knowing the MIME type, causing the server to store and serve them with a generic type. This leads to browsers saving files with `.bin` extensions and media failing to render inline in Nostr clients.
 
 If the blob was newly stored, the endpoint MUST respond with `201 Created` and a [Blob Descriptor](#blob-descriptor) in the response body.
 If the blob already exists, the endpoint MUST respond with `200 OK` and a [Blob Descriptor](#blob-descriptor) in the response body.


### PR DESCRIPTION
## Motivation

When automated clients (AI agents, CI pipelines, CLI tools) upload files without knowing the MIME type, they send `Content-Type: application/octet-stream`. The server then stores and serves the blob with this generic type, causing:

- Browsers to save files with a `.bin` extension
- Media (video, audio, images) to fail rendering inline in Nostr clients
- Incorrect `type` field in blob descriptors

Reported in #109 with real-world impact: Playwright video recordings uploaded via an agent client arrive as `.bin` files because the client content-type map does not include `.webm`.

## Changes

Adds a new **MIME type detection (Recommended)** subsection to BUD-02 that recommends servers detect MIME types from magic bytes when the client sends `application/octet-stream` or omits the header.

Key design decisions:

- **Only sniff when the client does not know** — if the client sends a specific type, trust it
- **Use well-maintained libraries** — file-type (Node.js), python-magic (Python)
- **Minimal overhead** — only needs the first few hundred bytes
- **Graceful fallback** — if detection fails, keep `application/octet-stream`

## Relationship to existing spec

This complements the existing **File extension normalization (Optional)** section. Server-side detection ensures the MIME type is correct, and normalization ensures the URL extension matches. Together they guarantee that the `type` and `url` fields in the blob descriptor are always accurate.

Closes #109